### PR TITLE
Add trusts controller with index, search and show actions

### DIFF
--- a/app/controllers/trusts_controller.rb
+++ b/app/controllers/trusts_controller.rb
@@ -1,0 +1,17 @@
+class TrustsController < ApplicationController
+  
+  # GET /trusts
+  def index
+  end
+
+  # GET /trusts/search
+  def search
+    @trusts = Trust.search(params[:query])
+  end
+
+  # GET /trusts/1
+  def show
+    @trust = Trust.find(params[:id])
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def page_header_label
+    content_for?(:page_header) ? content_for(:page_header) : t("default_page_header")
+  end
 end

--- a/app/helpers/trusts_helper.rb
+++ b/app/helpers/trusts_helper.rb
@@ -1,0 +1,2 @@
+module TrustsHelper
+end

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -15,6 +15,16 @@ class Trust
       payload = JSON.parse(response.body)
       payload.map { |input| new(input) }
     end
+
+    def find(id)
+      token = BearerToken.token
+      url = File.join(SEARCH_URL, id)
+      response = Faraday.get(url) do |req|
+        req.headers['Authorization']="Bearer #{token}"
+      end
+      payload = JSON.parse(response.body)
+      new(payload)
+    end
   end
 
   def initialize(attributes = {})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,21 +41,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "GOV.UK Rails Boilerplate", "/", class: "govuk-header__link govuk-header__link--service-name" %>
-          <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-                <%= link_to "Navigation item 1", "#", class: "govuk-header__link" %>
-              </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to "Navigation item 2", "#", class: "govuk-header__link" %>
-              </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to "Navigation item 3", "#", class: "govuk-header__link" %>
-              </li>
-            </ul>
-          </nav>
+          <%= link_to page_header_label, "/", class: "govuk-header__link govuk-header__link--service-name" %>
         </div>
       </div>
     </header>

--- a/app/views/trusts/index.html.erb
+++ b/app/views/trusts/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:page_header) { t(".page_header") } %>
+
+<div class="govuk-width-container"><br>
+  <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: search_trusts_path, method: :get, local: true do |form| %>
+    
+      <div class="govuk-form-group">
+        <%= form.label :query, t(".search_label"), class: "govuk-hint" %>
+
+      <%= form.text_field :query, class: "govuk-input" %>
+      </div>
+      <%= form.submit t(".search_button"), class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/trusts/search.html.erb
+++ b/app/views/trusts/search.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:page_header) { t(".page_header") } %>
+
+<div class="govuk-width-container"><br>
+  <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <ul>
+    <% @trusts.each do |trust| %>
+      <li><%= link_to trust.trust_name, trust_path(trust.id) %></li>
+    <% end %>
+  </div>
+</div>

--- a/app/views/trusts/show.html.erb
+++ b/app/views/trusts/show.html.erb
@@ -1,0 +1,29 @@
+<% content_for(:page_header) { t(".page_header") } %>
+
+<div class="govuk-width-container"><br>
+  <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+</div>
+
+<dl class="govuk-summary-list govuk-summary-list--no-border">
+  <% [
+       :trust_name,
+       :companies_house_number,
+       :establishment_type,
+       :trust_reference_number
+     ].each do |attribute| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
+      <dd class="govuk-summary-list__value"><%= @trust.send(attribute) %></dd>
+    </div>
+  <% end %>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key"><%= t(".address") %></dt>
+    <dd class="govuk-summary-list__value">
+      <% @trust.address.split(/[\n\r$\,]+/).each do |address_line| %>
+        <p class="govuk-body"><%= address_line %></p>
+      <% end %>
+    </dd>
+  </div>
+</dl>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,23 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  default_page_header: Academy Transfers
+
+  trusts:
+    index:
+      page_header: Transfer an academy to another trust
+      heading: Add the outgoing trust name
+      search_label: Search by name, trust reference number or companies house number
+      search_button: Search
+    search:
+      page_header: Transfer an academy to another trust
+      heading: Select Trust
+    show:
+      page_header: Transfer an academy to another trust
+      heading: Outgoing trust details
+      trust_name: Name
+      companies_house_number: Companies House Number
+      establishment_type: Type
+      trust_reference_number: Trust Reference Number
+      address: Address
+      

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  resources :trusts, only: [:index, :show] do
+    get :search, on: :collection
+  end
+
   get "/pages/:page", to: "pages#show"
 
   get "/404", to: "errors#not_found", via: :all

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['node_modules/govuk-frontend/govuk']
+  additional_paths: ['node_modules/govuk-frontend/govuk']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -4,6 +4,6 @@ RSpec.feature "View pages", type: :feature do
   scenario "Navigate to home" do
     visit "/pages/home"
 
-    expect(page).to have_text("Lorem")
+    expect(page).to have_text("Sign in to your DfE account")
   end
 end

--- a/spec/models/trust_spec.rb
+++ b/spec/models/trust_spec.rb
@@ -2,18 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Trust, type: :model do
   let(:trust) { build :trust }
-  let(:access_token) { SecureRandom.uuid }
 
   describe ".search" do
+    let(:results) { described_class.search("something") }
+
     before do
       mock_trust_search("something", [trust])
     end
 
-    it "returns matching trust" do
-      results = described_class.search("something")
-      
+    it "returns matching trust" do     
       expect(results.length).to eq(1)
       expect(results.first.as_json).to eq(trust.as_json)
+    end
+  end
+
+  describe ".find" do
+    let(:result) { described_class.find(trust.id) }
+
+    before do
+      mock_trust_find(trust)
+    end
+
+    it "returns the trust" do
+      expect(result.as_json).to eq(trust.as_json)
     end
   end
 end

--- a/spec/requests/trusts_spec.rb
+++ b/spec/requests/trusts_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "/trusts", type: :request do
+  let(:trust) { build :trust }
+  let(:query) { trust.trust_name }
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      get trusts_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /search" do
+    before do
+      mock_trust_search(query, [trust])
+      get search_trusts_url, params: { query: query }
+    end
+
+    it "renders a successful response" do
+      expect(response).to be_successful
+    end
+
+    it "displays link to trust's show page" do
+      expect(response.body).to include(trust.trust_name)
+      expect(response.body).to include(trust_path(trust.id))
+    end
+  end
+
+  describe "GET /show/:id" do
+    before do
+      mock_trust_find(trust)
+    end
+
+    it "renders a successful response" do
+      get trust_url(trust.id)
+      expect(response).to be_successful
+    end
+  end
+
+end

--- a/spec/support/webmock_stubs.rb
+++ b/spec/support/webmock_stubs.rb
@@ -15,3 +15,16 @@ def mock_trust_search(search_string, trusts_to_return)
     .with(headers: {"Authorization"=>"Bearer #{access_token}"})
     .to_return(body: body.to_json)
 end
+
+def mock_trust_find(trust)
+  url = File.join(Trust::SEARCH_URL, trust.id)
+
+  access_token = SecureRandom.uuid
+  mock_bearer_token_retrieval(access_token)
+
+  body = trust.as_json.transform_keys { |key| key.camelcase(:lower) }
+
+  stub_request(:get, url)
+    .with(headers: {"Authorization"=>"Bearer #{access_token}"})
+    .to_return(body: body.to_json)
+end


### PR DESCRIPTION
### Context
A trusts controller is need to allow users to interact with trusts.

### Changes proposed in this pull request
- Remove navigation from application as not used.
- Use translation file for static text rendered on page
- Use `content_for(:page_header)` to define layout content within page partial
- Add a `find` method to `Trust` to retrieve single trust using its `id`
- Replace `resolved_paths` with `additional_paths` in webpacker config to remove deprecation warnings

### Guidance to review

The pages created correspond to the prototype pages:
- https://at-prototype.london.cloudapps.digital/trust-name
- https://at-prototype.london.cloudapps.digital/trust-details

The main difference being search is carried out in two actions (enter search string, and then select result from next page), rather than using autocomplete on one page. So there are three pages rather than two. This behaviour can be changed to autocomplete when required. I just wanted to get this simpler working example up and running now to give something that can be demonstrated in the next task - getting the app hosted on PAAS.

The resulting pages look like this:

![trusts_index](https://user-images.githubusercontent.com/213040/102638298-30177e80-414f-11eb-97ed-ddc10bd21bd4.png)

![trusts_search](https://user-images.githubusercontent.com/213040/102637650-378a5800-414e-11eb-9fc3-f48b06a23434.png)

![trusts_show](https://user-images.githubusercontent.com/213040/102637654-39ecb200-414e-11eb-9064-f7fd53f87861.png)
