### PR TITLE
Allow credentials to be overwritten by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ or
 bundle exec scss-lint app/webpacker/styles
 ```
 
+## Configuration
+
+Custom credentials are configured in config/application.rb and are accessed within code via
+[Rails.configuration.x](https://guides.rubyonrails.org/configuring.html#custom-configuration)
+
+
+In development, [Rails Credentials](https://guides.rubyonrails.org/security.html#custom-credentials) are used to store
+secret credentials.
+
+Credentials can also be defined via environment variables (see config/application.rb) which is the intention for
+production environments. Credentials defined via environment credential take precidence.
+
 ## Deploying on GOV.UK PaaS
 
 ### Prerequisites

--- a/app/models/bearer_token.rb
+++ b/app/models/bearer_token.rb
@@ -17,9 +17,9 @@ class BearerToken
     @response ||= Faraday.post(
       SOURCE_URL,
       grant_type: 'client_credentials',
-      scope: Rails.application.credentials.api[:client_scope],
-      client_id: Rails.application.credentials.api[:client_id],
-      client_secret: Rails.application.credentials.api[:client_secret]
+      scope: Rails.configuration.x.api.client_scope,
+      client_id: Rails.configuration.x.api.client_id,
+      client_secret: Rails.configuration.x.api.client_secret
     )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,9 @@ module GovukRailsBoilerplate
     config.exceptions_app = routes
 
     config.middleware.use Rack::Deflater
+
+    Rails.configuration.x.api.client_scope = ENV.fetch("API_CLIENT_SCOPE", Rails.application.credentials.api[:client_scope])
+    Rails.configuration.x.api.client_id = ENV.fetch("API_CLIENT_ID", Rails.application.credentials.api[:client_id])
+    Rails.configuration.x.api.client_secret = ENV.fetch("API_CLIENT_SECRET", Rails.application.credentials.api[:client_secret])
   end
 end


### PR DESCRIPTION
### Context
Allows API credentials to be over-ridden by Environment Variables.

### Changes proposed in this pull request

Use `Rails.configuration.x` as main location for credentials and define them in config/application.rb

