### PR TITLE
Update code and rubocop config so that lint passes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,7 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+AllCops:
+  Exclude:
+    - node_modules/**/*
+    - db/schema.rb

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "canonical-rails"
 gem "faraday"
 
 # Manage Oauth2 authentication calls
-gem 'oauth2'
+gem "oauth2"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 
-task lint_ruby: ['lint:ruby']
-task lint_scss: ['lint:scss']
-task default: %i[spec lint_ruby lint_scss]
+task default: %w[spec lint:ruby lint:scss]

--- a/app/controllers/trusts_controller.rb
+++ b/app/controllers/trusts_controller.rb
@@ -1,8 +1,6 @@
 class TrustsController < ApplicationController
-  
   # GET /trusts
-  def index
-  end
+  def index; end
 
   # GET /trusts/search
   def search
@@ -13,5 +11,4 @@ class TrustsController < ApplicationController
   def show
     @trust = Trust.find(params[:id])
   end
-
 end

--- a/app/models/bearer_token.rb
+++ b/app/models/bearer_token.rb
@@ -1,5 +1,5 @@
 class BearerToken
-  SOURCE_URL = "https://login.microsoftonline.com/fad277c9-c60a-4da1-b5f3-b3b8b34a82f9/oauth2/v2.0/token"
+  SOURCE_URL = "https://login.microsoftonline.com/fad277c9-c60a-4da1-b5f3-b3b8b34a82f9/oauth2/v2.0/token".freeze
 
   def self.token
     new.token
@@ -16,10 +16,10 @@ class BearerToken
   def response
     @response ||= Faraday.post(
       SOURCE_URL,
-      grant_type: 'client_credentials',
+      grant_type: "client_credentials",
       scope: Rails.configuration.x.api.client_scope,
       client_id: Rails.configuration.x.api.client_id,
-      client_secret: Rails.configuration.x.api.client_secret
+      client_secret: Rails.configuration.x.api.client_secret,
     )
   end
 end

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -1,7 +1,7 @@
 class Trust
   include ActiveModel::Model
 
-  SEARCH_URL = "https://academy-transfers-prototype-api.london.cloudapps.digital/trusts"
+  SEARCH_URL = "https://academy-transfers-prototype-api.london.cloudapps.digital/trusts".freeze
 
   attr_accessor :id, :trust_name, :companies_house_number, :trust_reference_number, :address,
                 :establishment_type, :establishment_type_group, :ukprn, :upin
@@ -10,7 +10,7 @@ class Trust
     def search(content)
       token = BearerToken.token
       response = Faraday.get(SEARCH_URL, search: content) do |req|
-        req.headers['Authorization']="Bearer #{token}"
+        req.headers["Authorization"] = "Bearer #{token}"
       end
       payload = JSON.parse(response.body)
       payload.map { |input| new(input) }
@@ -20,7 +20,7 @@ class Trust
       token = BearerToken.token
       url = File.join(SEARCH_URL, id)
       response = Faraday.get(url) do |req|
-        req.headers['Authorization']="Bearer #{token}"
+        req.headers["Authorization"] = "Bearer #{token}"
       end
       payload = JSON.parse(response.body)
       new(payload)
@@ -28,7 +28,7 @@ class Trust
   end
 
   def initialize(attributes = {})
-    attributes.transform_keys! {|key| key.to_s.underscore}
+    attributes.transform_keys! { |key| key.to_s.underscore }
     super
   end
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,9 +13,9 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies
   # system('bin/yarn')
@@ -26,11 +26,11 @@ FileUtils.chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:prepare'
+  system! "bin/rails db:prepare"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/spring
+++ b/bin/spring
@@ -4,14 +4,14 @@
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
+  require "rubygems"
+  require "bundler"
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
   spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
   end
 end

--- a/bin/update
+++ b/bin/update
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,19 +13,19 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/webpack
+++ b/bin/webpack
@@ -5,7 +5,7 @@ ENV["NODE_ENV"]  ||= "development"
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+                                           Pathname.new(__FILE__).realpath)
 
 require "rubygems"
 require "bundler/setup"

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -5,7 +5,7 @@ ENV["NODE_ENV"]  ||= "development"
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+                                           Pathname.new(__FILE__).realpath)
 
 require "rubygems"
 require "bundler/setup"

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,11 +1,9 @@
 #!/usr/bin/env ruby
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg", *ARGV
+rescue Errno::ENOENT
+  warn "Yarn executable was not detected in the system."
+  warn "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -8,7 +8,7 @@ CanonicalRails.setup do |config|
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
   config.host = "www.education.gov.uk"
-  config.port# = '3000'
+  config.port # = '3000'
 
   # http://en.wikipedia.org/wiki/URL_normalization
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;
@@ -16,12 +16,12 @@ CanonicalRails.setup do |config|
   #
   # Acts as a whitelist for routes to have trailing slashes
 
-  config.collection_actions# = [:index]
+  config.collection_actions # = [:index]
 
   # Parameter spamming can cause index dilution by creating seemingly different URLs with identical or near-identical content.
   # Unless whitelisted, these parameters will be omitted
 
-  config.whitelisted_parameters# = []
+  config.whitelisted_parameters # = []
 
   # Output a matching OpenGraph URL meta tag (og:url) with the canonical URL, as recommended by Facebook et al
   config.opengraph_url = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :trusts, only: [:index, :show] do
+  resources :trusts, only: %i[index show] do
     get :search, on: :collection
   end
 

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -1,10 +1,12 @@
 desc "Lint ruby code"
 namespace :lint do
+  desc "Ruby lint via rubocop"
   task ruby: :environment do
     puts "Linting ruby..."
     system "bundle exec rubocop app config db lib spec Gemfile --format clang -a"
   end
 
+  desc "SCSS lint"
   task scss: :environment do
     puts "Linting scss..."
     system "bundle exec scss-lint app/webpacker/styles"

--- a/spec/models/bearer_token_spec.rb
+++ b/spec/models/bearer_token_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe BearerToken do
   let(:access_token) { SecureRandom.uuid }

--- a/spec/models/trust_spec.rb
+++ b/spec/models/trust_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Trust, type: :model do
   let(:trust) { build :trust }
@@ -10,7 +10,7 @@ RSpec.describe Trust, type: :model do
       mock_trust_search("something", [trust])
     end
 
-    it "returns matching trust" do     
+    it "returns matching trust" do
       expect(results.length).to eq(1)
       expect(results.first.as_json).to eq(trust.as_json)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'webmock/rspec'
+require "webmock/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -22,7 +22,7 @@ require 'webmock/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/trusts_spec.rb
+++ b/spec/requests/trusts_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "/trusts", type: :request do
   let(:trust) { build :trust }
@@ -37,5 +37,4 @@ RSpec.describe "/trusts", type: :request do
       expect(response).to be_successful
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/support/webmock_stubs.rb
+++ b/spec/support/webmock_stubs.rb
@@ -12,7 +12,7 @@ def mock_trust_search(search_string, trusts_to_return)
   body = trusts_to_return.map { |trust| trust.as_json.transform_keys { |key| key.camelcase(:lower) } }
 
   stub_request(:get, uri.to_s)
-    .with(headers: {"Authorization"=>"Bearer #{access_token}"})
+    .with(headers: { "Authorization" => "Bearer #{access_token}" })
     .to_return(body: body.to_json)
 end
 
@@ -25,6 +25,6 @@ def mock_trust_find(trust)
   body = trust.as_json.transform_keys { |key| key.camelcase(:lower) }
 
   stub_request(:get, url)
-    .with(headers: {"Authorization"=>"Bearer #{access_token}"})
+    .with(headers: { "Authorization" => "Bearer #{access_token}" })
     .to_return(body: body.to_json)
 end


### PR DESCRIPTION
### Context
Having rubocop in place and the code compliant to the current policy makes it easier maintain a consistent standard of code quality.

Doing this now (early on in the development process) while it is easy to do.

### Changes proposed in this pull request

- Exclude node modules and schema from rubocop
- Remove undescribed intermediate linting tasks from default
- Add descriptions to tasks
- Accept rubocop automated changes


