### PR TITLE
Add Redis to cache some API calls responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem "faker"
 # User authentication
 gem "devise"
 
+# Redis data store used for caching
+gem "redis"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.5)
     regexp_parser (1.8.2)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -314,6 +315,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.0)
   rails (~> 6.0.3)
+  redis
   rspec-rails (~> 4.0.1)
   rubocop-govuk
   scss_lint-govuk

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -9,10 +9,13 @@ class Trust
   class << self
     def search(content)
       token = BearerToken.token
-      response = Faraday.get(SEARCH_URL, search: content) do |req|
-        req.headers["Authorization"] = "Bearer #{token}"
+      payload = BlockCache.with(content, namespace: :trusts) do
+        response = Faraday.get(SEARCH_URL, search: content) do |req|
+          req.headers["Authorization"] = "Bearer #{token}"
+        end
+        response.body
       end
-      payload = JSON.parse(response.body)
+      payload = JSON.parse(payload)
       payload.map { |input| new(input) }
     end
 

--- a/app/services/block_cache.rb
+++ b/app/services/block_cache.rb
@@ -1,0 +1,56 @@
+class BlockCache
+  EXPIRY = 5.minutes
+
+  def self.with(key, namespace: nil, &block)
+    new(key, namespace: namespace, &block).result
+  end
+
+  def self.redis
+    @redis ||= Redis.new(redis_credentials)
+  end
+
+  def self.redis_credentials
+    vcap_services = ENV["VCAP_SERVICES"]
+    return {} if vcap_services.blank?
+
+    @redis_credentials ||= begin
+      credentials = JSON.parse(vcap_services)
+      url = credentials.dig("redis", 0, "credentials", "uri")
+      url ? { url: url } : {}
+    end
+  end
+
+  delegate :redis, to: :class
+
+  attr_reader :key, :namespace, :block
+
+  def initialize(key, namespace: nil, &block)
+    @key = key
+    @namespace = namespace.to_s
+    @block = block
+  end
+
+  def redis_key
+    @redis_key ||= [Rails.env, "block_cache", namespace, key].select(&:present?).join("_")
+  end
+
+  def result
+    return cached if cached
+
+    save_live_in_cache
+    live
+  end
+
+  def cached
+    redis.get(redis_key)
+  end
+
+  def save_live_in_cache
+    redis.set(redis_key, live)
+    redis.expire(redis_key, EXPIRY)
+  end
+
+  def live
+    @live ||= block.call
+  end
+end

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,3 +7,4 @@ applications:
     - https://github.com/cloudfoundry/nodejs-buildpack
   services:
     - academy-transfers-prototype-frontend-db
+    - academy-transfers-prototype-frontend-redis

--- a/spec/requests/trusts_spec.rb
+++ b/spec/requests/trusts_spec.rb
@@ -5,8 +5,11 @@ RSpec.describe "/trusts", type: :request do
   let(:query) { trust.trust_name }
   let(:trusts) { [trust] }
   let(:user) { create :user }
+  let(:redis) { Redis.new }
+  let(:redis_key) { "test_block_cache_trusts_#{query}" }
 
   before do
+    redis.del(redis_key)
     sign_in user
   end
 
@@ -45,8 +48,9 @@ RSpec.describe "/trusts", type: :request do
 
   describe "GET /search.json" do
     let(:query) { Faker::Educator.secondary_school }
-    let(:trusts) { build_list :trust, 2, trust_name: query }
-    let(:trust) { trusts.first }
+    let(:trust) { build :trust, trust_name: "#{query} one" }
+    let(:trust_two) { build :trust, trust_name: "#{query} two" }
+    let(:trusts) { [trust, trust_two] }
 
     before do
       mock_trust_search(query, trusts)
@@ -54,7 +58,7 @@ RSpec.describe "/trusts", type: :request do
     end
 
     it "returns the trust names" do
-      expect(response.body).to eq([query, query].to_json)
+      expect(response.body).to eq([trust.trust_name, trust_two.trust_name].to_json)
     end
   end
 

--- a/spec/services/block_cache_spec.rb
+++ b/spec/services/block_cache_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe BlockCache do
+  let(:payload) { Faker::Lorem.sentence }
+  let(:key) { Faker::Lorem.word }
+  let(:redis_key) { "test_block_cache_#{key}" }
+  let(:redis) { described_class.redis }
+
+  describe ".with" do
+    let(:result) do
+      described_class.with(key) { payload }
+    end
+
+    before { redis.del(redis_key) }
+
+    it "returns payload" do
+      expect(result).to eq(payload)
+    end
+
+    it "adds payload to redis" do
+      result
+      expect(redis.get(redis_key)).to eq(payload)
+    end
+
+    context "with cached content" do
+      let(:cached) { Faker::Lorem.sentence }
+
+      before { redis.set(redis_key, cached) }
+
+      it "returns cached" do
+        expect(result).to eq(cached)
+      end
+    end
+
+    context "with namespace" do
+      let(:namespace) { Faker::Lorem.word }
+      let(:redis_key) { "test_block_cache_#{namespace}_#{key}" }
+      let(:result) do
+        described_class.with(key, namespace: namespace) { payload }
+      end
+
+      it "returns payload" do
+        expect(result).to eq(payload)
+      end
+
+      it "adds payload to redis" do
+        result
+        expect(redis.get(redis_key)).to eq(payload)
+      end
+    end
+  end
+
+  describe ".redis_credentials" do
+    it "returns empty hash" do
+      expect(described_class.redis_credentials).to eq({})
+    end
+
+    context "with credentials in environment variable" do
+      let(:url) { Faker::Internet.url }
+      let(:credentials) do
+        {
+          redis: [
+            {
+              credentials: { uri: url },
+            },
+          ],
+        }
+      end
+      before do
+        allow(ENV).to receive(:[]).with("VCAP_SERVICES").and_return(credentials.to_json)
+      end
+
+      it "returns url" do
+        expect(described_class.redis_credentials).to eq({ url: url })
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Trust search can generate a call back to the backend API with each keystroke when entering a search string. This can cause delays and unexpected behaviour ("a" returns more matches than "ab" so can take longer to return. Sometimes that means the early query returns after the later one and appears as the "current" match). Caching locally greatly improves the performance and reliability.

### Changes proposed in this pull request

- add redis gem
- add BlockCache service to manage caching of content from blocks
- use block cache to cache trusts search
- add specs for new and changed behaviour
- add PAAS redis service to deployment manifest
- retrieve redis credentials from ENV["VCAP_SERVICES"]