### PR TITLE
Search and select name of trust (incoming)

### DIFF
--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -1,7 +1,40 @@
 class IncomingTrustsController < ApplicationController
   def index; end
 
-  def search; end
+  def create
+    case params[:trust_identified]
+    when "yes"
+      redirect_to identified_trust_incoming_trusts_path(params[:trust_id])
+    when "no"
+      render plain: "Redirect to page not build yet"
+    else
+      @error = I18n.t("errors.must_select_yes_or_no")
+      render :index
+    end
+  end
 
-  def show; end
+  def identified; end
+
+  def search
+    @trusts = Trust.search(params["input-autocomplete"])
+
+    redirect_to trust_incoming_trust_path(params[:trust_id], @trusts.first.id) if @trusts.one?
+  end
+
+  def show
+    session_store.set :incoming_trusts, [params[:id]]
+    @outgoing_trust = Trust.find(params[:trust_id])
+    @academies = Academy.belonging_to_trust(@outgoing_trust.id).select { |academy| selected_academy_ids.include?(academy.id) }
+    @incoming_trust = Trust.find(params[:id])
+  end
+
+private
+
+  def session_store
+    @session_store ||= SessionStore.new(current_user, params[:trust_id])
+  end
+
+  def selected_academy_ids
+    session_store.get(:academy_ids)
+  end
 end

--- a/app/models/academy.rb
+++ b/app/models/academy.rb
@@ -27,4 +27,10 @@ class Academy
 
     "#{academy_name} (URN #{urn})"
   end
+
+  def ofsted_inspection_date_formatted
+    return if ofsted_inspection_date.blank?
+
+    Date.parse(ofsted_inspection_date).to_s(:govuk)
+  end
 end

--- a/app/views/academies/index.html.erb
+++ b/app/views/academies/index.html.erb
@@ -4,13 +4,13 @@
 
 <%= form_with(url: trust_academies_path(params[:trust_id]), local: true) do |form| %>
   <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+    <fieldset class="govuk-fieldset" aria-describedby="academy-hint">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading">
           <%= t(".heading") %>
         </h1>
       </legend>
-      <div id="waste-hint" class="govuk-hint">
+      <div id="academy-hint" class="govuk-hint">
         <%= t(".hint") %>
       </div>
       <div class="govuk-checkboxes">

--- a/app/views/incoming_trusts/identified.html.erb
+++ b/app/views/incoming_trusts/identified.html.erb
@@ -1,0 +1,19 @@
+<% content_for(:page_header) { t(".page_header") } %>
+
+<div class="govuk-width-container"><br>
+  <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: search_trust_incoming_trusts_path, method: :get, local: true do |form| %>
+
+      <div class="govuk-form-group">
+        <%= form.label :autocomplete_trusts, t(".search_label"), class: "govuk-hint" %>
+        <div id="autocomplete_trusts"></div>
+      </div>
+      <%= form.submit t(".search_button"), class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/incoming_trusts/index.html.erb
+++ b/app/views/incoming_trusts/index.html.erb
@@ -1,2 +1,33 @@
-<h1>IncomingTrusts#index</h1>
-<p><%= SessionStore.new(current_user, params[:trust_id]).get(:academy_ids) %></p>
+<% content_for(:page_header) { t(".page_header") } %>
+
+<%= render("error_summary", errors: [@error]) if @error %>
+
+<%= form_with(url: trust_incoming_trusts_path(params[:trust_id]), local: true) do |form| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+          <%= t(".heading") %>
+        </h1>
+      </legend>
+      <div class="govuk-radios govuk-radios--inline">
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="trust-identified" name="trust_identified" type="radio" value="yes">
+          <label class="govuk-label govuk-radios__label" for="trust-identified">
+            <%= t(".generic.yes") %>
+          </label>
+        </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="trust-identified-2" name="trust_identified" type="radio" value="no">
+          <label class="govuk-label govuk-radios__label" for="trust-identified-2">
+            <%= t(".generic.no") %>
+          </label>
+        </div>
+      </div>
+    </fieldset>
+
+    <div class="govuk-!-margin-top-4">
+      <%= form.submit t(".submit"), class: "govuk-button" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/incoming_trusts/search.html.erb
+++ b/app/views/incoming_trusts/search.html.erb
@@ -1,2 +1,14 @@
-<h1>IncomingTrusts#search</h1>
-<p>Find me in app/views/incoming_trusts/search.html.erb</p>
+<% content_for(:page_header) { t(".page_header") } %>
+
+<div class="govuk-width-container"><br>
+  <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <ul>
+    <% @trusts.each do |trust| %>
+      <li><%= link_to trust.trust_name, trust_incoming_trust_path(params[:trust_id], trust.id) %></li>
+    <% end %>
+  </div>
+</div>

--- a/app/views/incoming_trusts/show.html.erb
+++ b/app/views/incoming_trusts/show.html.erb
@@ -1,2 +1,71 @@
-<h1>IncomingTrusts#show</h1>
-<p>Find me in app/views/incoming_trusts/show.html.erb</p>
+<% content_for(:page_header) { t(".page_header") } %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+</div>
+
+<div class="govuk-width-container">
+  <h2 class="govuk-heading-m"><%= t(".outgoing_trust") %></h2>
+  <dl class="govuk-summary-list">
+    <% [
+         :trust_name,
+         :trust_reference_number
+       ].each do |attribute| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
+        <dd class="govuk-summary-list__value"><%= @outgoing_trust.send(attribute) %></dd>
+      </div>
+    <% end %>
+  </dl>
+</div>
+
+<div class="govuk-width-container">
+  <h2 class="govuk-heading-m"><%= t("academy_details") %></h2>
+
+  <% @academies.each do |academy| %>
+    <dl class="govuk-summary-list">
+      <% [
+         :academy_name,
+         :urn,
+         :local_authority_name,
+         :establishment_type,
+         :religious_character,
+         :ofsted_rating,
+         :ofsted_inspection_date_formatted,
+         :pfi
+       ].each do |attribute| %>
+          <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
+          <dd class="govuk-summary-list__value"><%= academy.send(attribute) %></dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+</div>
+
+<div class="govuk-width-container">
+  <h2 class="govuk-heading-m"><%= t(".incoming_trusts") %></h2>
+
+  <dl class="govuk-summary-list">
+    <% [
+         :trust_name,
+         :companies_house_number,
+         :trust_reference_number,
+         :establishment_type
+       ].each do |attribute| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
+        <dd class="govuk-summary-list__value"><%= @incoming_trust.send(attribute) %></dd>
+      </div>
+    <% end %>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key"><%= t(".address") %></dt>
+      <dd class="govuk-summary-list__value">
+        <% @incoming_trust.address.split(/[\n\r$\,]+/).each do |address_line| %>
+          <p class="govuk-body"><%= address_line %></p>
+        <% end %>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,25 @@ en:
       heading: Dashboard
       new_academy_transfer: Set up a new academy transfer project
       new_academy_transfer_button: Start a new project
+  incoming_trusts:
+    index:
+      page_header: Transfer an academy to another trust
+      heading: Has an incoming trust been identified?
+      submit: Continue
+    identified:
+      page_header: Transfer an academy to another trust
+      heading: Add the incoming trust name
+      search_label: Search by name, trust reference number or companies house number
+      search_button: Search and continue
+    search:
+      page_header: Transfer an academy to another trust
+      heading: Select incoming trust
+    show:
+      page_header: Transfer an academy to another trust
+      heading: Check trust and academy details
+      outgoing_trust: Outgoing trust
+      academy_details: Academy details
+      incoming_trusts: Incoming trusts
   trusts:
     index:
       page_header: Transfer an academy to another trust
@@ -67,4 +86,9 @@ en:
     summary: There is a problem
     trust:
       no_academy_selected: An academy must be selected
+    must_select_yes_or_no: Yes or No must be selected
+
+  generic:
+    yes: Yes
+    no: No
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,11 @@ Rails.application.routes.draw do
   resources :trusts, only: %i[index show] do
     get :search, on: :collection
     resources :academies, only: %i[index create]
-    resources :incoming_trusts, only: %i[index show], path: :incoming do
-      get :search, on: :collection
+    resources :incoming_trusts, only: %i[index show create], path: :incoming do
+      collection do
+        get :identified
+        get :search
+      end
     end
   end
 

--- a/spec/models/academy_spec.rb
+++ b/spec/models/academy_spec.rb
@@ -15,4 +15,30 @@ RSpec.describe Academy, type: :model do
       expect(results.map(&:as_json)).to match_array(academies.map(&:as_json))
     end
   end
+
+  describe "#ofsted_inspection_date_formatted" do
+    let(:academy) { build :academy }
+
+    it "is in govuk format" do
+      date = Date.parse(academy.ofsted_inspection_date)
+      expect(academy.ofsted_inspection_date_formatted).to eq(date.to_s(:govuk))
+    end
+  end
+
+  describe "#academy_name_with_urn" do
+    let(:urn) { "123456" }
+    let(:academy) { build :academy, academy_name: "Foo", urn: urn }
+
+    it "display both name and urn" do
+      expect(academy.academy_name_with_urn).to eq("Foo (URN 123456)")
+    end
+
+    context "without urn" do
+      let(:urn) { nil }
+
+      it "displays the name" do
+        expect(academy.academy_name_with_urn).to eq("Foo")
+      end
+    end
+  end
 end

--- a/spec/requests/incoming_trusts_spec.rb
+++ b/spec/requests/incoming_trusts_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe "IncomingTrusts", type: :request do
   let(:trust) { build :trust }
+  let(:outgoing_trust) { trust }
+  let(:incoming_trust) { build :trust }
   let(:user) { create :user }
 
   before { sign_in user }
@@ -10,6 +12,110 @@ RSpec.describe "IncomingTrusts", type: :request do
     it "returns http success" do
       get trust_incoming_trusts_path(trust.id)
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST /trust/:trust_id/incoming" do
+    let(:trust_identified) { "yes" }
+    let(:params) do
+      { trust_identified: trust_identified }
+    end
+    subject { post trust_incoming_trusts_path(trust.id), params: params }
+
+    it "redirects to identified" do
+      subject
+      expect(response).to redirect_to(identified_trust_incoming_trusts_path(trust.id))
+    end
+
+    context "when no trust identified" do
+      let(:trust_identified) { "no" }
+
+      xit "redirects to ..." do
+        subject
+        expect(response).to redirect_to(:tbc)
+      end
+    end
+
+    context "when nothing selected" do
+      let(:trust_identified) { nil }
+
+      it "successfully renders page" do
+        subject
+        expect(response).to have_http_status(:success)
+      end
+
+      it "displays error" do
+        subject
+        expect(response.body).to include(I18n.t("errors.must_select_yes_or_no"))
+      end
+    end
+  end
+
+  describe "GET /trust/:trust_id/incoming/identified" do
+    it "returns http success" do
+      get identified_trust_incoming_trusts_path(trust.id)
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /trusts/:trust_id/incoming/search" do
+    let(:query) { incoming_trust.trust_name }
+    let(:trusts) { [incoming_trust] }
+    let(:redis) { Redis.new }
+    let(:redis_key) { "test_block_cache_trusts_#{query}" }
+
+    before do
+      redis.del(redis_key)
+      mock_trust_search(query, trusts)
+      get search_trust_incoming_trusts_url(outgoing_trust.id), params: { "input-autocomplete" => query }
+    end
+
+    it "Redirects to show for single result" do
+      expect(response).to redirect_to(trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id))
+    end
+
+    context "when multiple results" do
+      let(:query) { Faker::Educator.secondary_school }
+      let(:trusts) { build_list :trust, 2, trust_name: query }
+      let(:incoming_trust) { trusts.first }
+
+      it "renders a successful response" do
+        expect(response).to be_successful
+      end
+
+      it "displays link to incoming trust's show page" do
+        expect(response.body).to include(incoming_trust.trust_name)
+        expect(response.body).to include(trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id))
+      end
+    end
+  end
+
+  describe "GET /trusts/:trust_id/incoming/:id" do
+    let(:session_store) { SessionStore.new(user, trust.id) }
+    let(:academy) { build :academy }
+
+    before do
+      mock_academies_belonging_to_trust(outgoing_trust, [academy])
+      mock_trust_find(incoming_trust)
+      mock_trust_find(outgoing_trust)
+      session_store.set :academy_ids, [academy.id]
+      get trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id)
+    end
+
+    it "renders a successful response" do
+      expect(response).to be_successful
+    end
+
+    it "displays outgoing trust information" do
+      expect(response.body).to include(outgoing_trust.trust_reference_number)
+    end
+
+    it "displays incoming trust information" do
+      expect(response.body).to include(incoming_trust.trust_reference_number)
+    end
+
+    it "displays academy information" do
+      expect(response.body).to include(academy.urn)
     end
   end
 end


### PR DESCRIPTION
### Context
As a user :
I want to confirm if an incoming Trust has been identified, so that I can search and select the incoming trust.

Given that I have selected the YES option 
AND the search page is displayed 
When I type name of trust or ID 
Then I should be able to search and  select the incoming trust

### Changes proposed in this pull request
Update incoming trusts controller to allow user to identify incoming trust

- Add actions to allow user to confirm incoming identified
- Add actions to search for incoming trust and select required one if necessary
- Add action to display result
- Fix wrong hint id in academies#index view
- Add missing unit test for academy#name_with_urn

### Guidance to review

This version of the code is currently on the live server.

[Trello card](https://trello.com/c/5FVGDOSV/530-search-and-select-name-of-trust-incoming)
