### PR TITLE
Add action to POST project data to the API and create a project there

### DIFF
--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -4,7 +4,7 @@ class IncomingTrustsController < ApplicationController
   def create
     case params[:trust_identified]
     when "yes"
-      redirect_to identified_trust_incoming_trusts_path(params[:trust_id])
+      redirect_to identified_trust_incoming_trusts_path(outgoing_trust_id)
     when "no"
       render plain: "Redirect to page not build yet"
     else
@@ -18,12 +18,12 @@ class IncomingTrustsController < ApplicationController
   def search
     @trusts = Trust.search(params["input-autocomplete"])
 
-    redirect_to trust_incoming_trust_path(params[:trust_id], @trusts.first.id) if @trusts.one?
+    redirect_to trust_incoming_trust_path(outgoing_trust_id, @trusts.first.id) if @trusts.one?
   end
 
   def show
     session_store.set :incoming_trusts, [params[:id]]
-    @outgoing_trust = Trust.find(params[:trust_id])
+    @outgoing_trust = Trust.find(outgoing_trust_id)
     @academies = Academy.belonging_to_trust(@outgoing_trust.id).select { |academy| selected_academy_ids.include?(academy.id) }
     @incoming_trust = Trust.find(params[:id])
   end
@@ -36,5 +36,9 @@ private
 
   def selected_academy_ids
     session_store.get(:academy_ids)
+  end
+
+  def outgoing_trust_id
+    @outgoing_trust_id = params[:trust_id]
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,29 @@
+class ProjectsController < ApplicationController
+  # POST /trusts/:trust_id/projects
+  def create
+    @project = Project.new(project_params)
+
+    api_response = @project.save
+    render json: {
+      "API Response" => api_response,
+      "Submitted data" => @project.api_payload,
+    }
+  end
+
+private
+
+  def project_params
+    {
+      project_initiator_uid: current_user.uid,
+      project_initiator_full_name: current_user.username,
+      project_status: Project::STATUS[:in_progress],
+      academy_ids: session_store.get(:academy_ids),
+      outgoing_trust_id: params[:trust_id],
+      incoming_trust_id: session_store.get(:incoming_trusts).first,
+    }
+  end
+
+  def session_store
+    @session_store ||= SessionStore.new(current_user, params[:trust_id])
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,61 @@
+class Project
+  include ActiveModel::Model
+
+  SAVE_URL = "https://academy-transfers-prototype-api.london.cloudapps.digital/projects".freeze
+
+  STATUS = {
+    in_progress: 1,
+    completed: 2,
+  }.freeze
+
+  ESFA_REASONS = {
+    1 => "Governance Concerns",
+    2 => "Finance Concerns",
+    3 => "Irregularity Concerns",
+    4 => "Safeguarding Concerns",
+  }.freeze
+
+  RSC_REASONS = {
+    1 => "Termination Warning Notice",
+    2 => "RSC Minded to Terminate Notice",
+    3 => "Ofsted Inadequate Rating",
+  }.freeze
+
+  attr_accessor :project_id, :project_name, :project_initiator_full_name, :project_initiator_uid, :project_status,
+                :esfa_intervention_reasons, :esfa_intervention_reasons_explained, :rdd_or_rsc_intervention_reasons,
+                :rdd_or_rsc_intervention_reasons_explained, :academy_ids, :outgoing_trust_id, :incoming_trust_id
+
+  def save
+    token = BearerToken.token
+    Faraday.post(SAVE_URL, api_payload.to_json, "Content-Type" => "application/json") do |req|
+      req.headers["Authorization"] = "Bearer #{token}"
+    end
+  end
+
+  def api_payload
+    {
+      project_initiator_uid: project_initiator_uid,
+      project_initiator_full_name: project_initiator_full_name,
+      project_status: project_status,
+      project_academies: project_academies,
+      project_trusts: [
+        { trust_id: incoming_trust_id },
+      ],
+    }.deep_transform_keys { |key| key.to_s.camelize(:lower) }
+  end
+
+  def project_academies
+    academy_ids.map do |academy_id|
+      {
+        academy_id: academy_id,
+        esfa_intervention_reasons: esfa_intervention_reasons&.select(&:present?),
+        esfa_intervention_reasons_explained: esfa_intervention_reasons_explained,
+        rdd_or_rsc_intervention_reasons: rdd_or_rsc_intervention_reasons&.select(&:present?),
+        rdd_or_rsc_intervention_reasons_explained: rdd_or_rsc_intervention_reasons_explained,
+        trusts: [
+          { trust_id: outgoing_trust_id },
+        ],
+      }
+    end
+  end
+end

--- a/app/views/incoming_trusts/show.html.erb
+++ b/app/views/incoming_trusts/show.html.erb
@@ -69,3 +69,7 @@
     </div>
   </dl>
 </div>
+
+<div class="govuk-width-container">
+  <%= link_to t(".next_action_link"), trust_projects_path(@outgoing_trust_id), method: :post, class: "govuk-button" %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
       outgoing_trust: Outgoing trust
       academy_details: Academy details
       incoming_trusts: Incoming trusts
+      next_action_link: Save and continue
   trusts:
     index:
       page_header: Transfer an academy to another trust

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
         get :search
       end
     end
+    resources :projects, only: %i[create]
   end
 
   get "/pages/:page", to: "pages#show"

--- a/db/migrate/20210115153949_add_uid_to_users.rb
+++ b/db/migrate/20210115153949_add_uid_to_users.rb
@@ -1,0 +1,6 @@
+class AddUidToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :uid, :string
+    add_index :users, :uid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_111520) do
+ActiveRecord::Schema.define(version: 2021_01_15_153949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 2020_12_22_111520) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "uid"
+    t.index ["uid"], name: "index_users_on_uid"
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,4 +2,5 @@
 
 default_user = User.find_or_initialize_by(username: Rails.configuration.x.default_user.username)
 default_user.password = Rails.configuration.x.default_user.password
+default_user.uid ||= SecureRandom.uuid
 default_user.save!

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :project do
+    project_id { SecureRandom.uuid }
+    project_name { Faker::Company.catch_phrase }
+    project_initiator_full_name { Faker::Internet.safe_email }
+    project_initiator_uid { SecureRandom.uuid }
+    project_status { [1, 2].sample }
+    esfa_intervention_reasons { [(1..4).to_a.sample] }
+    esfa_intervention_reasons_explained { Faker::Lorem.paragraph }
+    rdd_or_rsc_intervention_reasons { [(1..3).to_a.sample] }
+    rdd_or_rsc_intervention_reasons_explained { Faker::Lorem.paragraph }
+    academy_ids { [SecureRandom.uuid] }
+    outgoing_trust_id { SecureRandom.uuid }
+    incoming_trust_id { SecureRandom.uuid }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :user do
+    username { Faker::Name.name.gsub(/\s/, ".") }
+    uid { SecureRandom.uuid }
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Project, type: :model do
+  let(:user) { create :user }
+  let(:academy) { build :academy }
+  let(:incoming_trust) { build :trust }
+  let(:outgoing_trust) { build :trust }
+  let(:project_status) { Project::STATUS[:in_progress] }
+  let(:project) do
+    described_class.new(
+      project_initiator_uid: user.uid,
+      project_initiator_full_name: user.username,
+      project_status: project_status,
+      academy_ids: [academy.id],
+      outgoing_trust_id: outgoing_trust.id,
+      incoming_trust_id: incoming_trust.id,
+    )
+  end
+
+  describe "#save" do
+    let(:response) { project.save }
+    let(:response_body) { { foo: :bar }.to_json }
+
+    before do
+      mock_project_save(project, response_body)
+    end
+
+    it "posts the api payload to the API" do
+      expect(response.status).to eq(200)
+      expect(response.body).to eq(response_body)
+    end
+  end
+
+  describe "#api_payload" do
+    let(:api_payload) { project.api_payload }
+    it "contains the user data" do
+      expect(api_payload["projectInitiatorUid"]).to eq(user.uid)
+      expect(api_payload["projectInitiatorFullName"])
+    end
+
+    it "contains the product status" do
+      expect(api_payload["projectStatus"]).to eq(project_status)
+    end
+
+    it "contains the project_academies" do
+      expect(api_payload.dig("projectAcademies", 0, "academyId")).to eq(academy.id)
+    end
+
+    it "contains the incoming trust id" do
+      expect(api_payload.dig("projectTrusts", 0, "trustId")).to eq(incoming_trust.id)
+    end
+  end
+
+  describe "#project_academies" do
+    let(:project_academy) { project.project_academies.first }
+
+    it "contains academy id" do
+      expect(project_academy[:academy_id]).to eq(academy.id)
+    end
+
+    it "contain outgoing trust id" do
+      expect(project_academy.dig(:trusts, 0, :trust_id)).to eq(outgoing_trust.id)
+    end
+  end
+end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "/projects", type: :request do
+  let(:user) { create :user }
+  let(:academy) { build :academy }
+  let(:incoming_trust) { build :trust }
+  let(:outgoing_trust) { build :trust }
+  let(:project_status) { Project::STATUS[:in_progress] }
+  let(:project) do
+    Project.new(
+      project_initiator_uid: user.uid,
+      project_initiator_full_name: user.username,
+      project_status: project_status,
+      academy_ids: [academy.id],
+      outgoing_trust_id: outgoing_trust.id,
+      incoming_trust_id: incoming_trust.id,
+    )
+  end
+  let(:session_store) { SessionStore.new(user, outgoing_trust.id) }
+
+  describe "POST /trusts/:trust_id/projects" do
+    let(:response_body) { { foo: :bar }.to_json }
+
+    before do
+      sign_in user
+      session_store.set(:academy_ids, [academy.id])
+      session_store.set(:incoming_trusts, [incoming_trust.id])
+      mock_project_save(project, response_body)
+    end
+    subject { post trust_projects_path(outgoing_trust.id) }
+
+    it "renders successfully" do
+      subject
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/support/webmock_stubs.rb
+++ b/spec/support/webmock_stubs.rb
@@ -36,6 +36,17 @@ def mock_academies_belonging_to_trust(trust, academies)
     .to_return(body: body.to_json)
 end
 
+def mock_project_save(project, response_body = {})
+  url = Project::SAVE_URL
+  mock_bearer_token_retrieval(mock_api_access_token)
+
+  stub_request(:post, url)
+    .with(
+      body: project.api_payload.to_json,
+      headers: { "Authorization" => "Bearer #{mock_api_access_token}" },
+    ).to_return(body: response_body)
+end
+
 def mock_api_access_token
   @mock_api_access_token ||= SecureRandom.uuid
 end


### PR DESCRIPTION
### Context
The project should be saved to the API when the user is happy with the data on the summary page.

### Changes proposed in this pull request
The action is triggered by clicking Save and continue of the project summary page

- Add a project model
- Add a projects controller with a single action - :create
- Update User by adding a uid field
- Add a stub for project save

### Guidance to review

On submission the response is rendered as a JSON object which contains the API response and the data that was submitted to it. This is a temporary behaviour to demonstrate that the system is working as expected, and will be replace when the next page in the journey is created. Here is an example of a successful response:

![temp_post_reponse](https://user-images.githubusercontent.com/213040/104753167-862c1180-574f-11eb-8b51-9fe83c680cad.png)
