### PR TITLE
Set API root URL in application, and allow it to be defined via an environment variable

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,7 @@
 class Project
   include ActiveModel::Model
 
-  SAVE_URL = "https://academy-transfers-prototype-api.london.cloudapps.digital/projects".freeze
+  SAVE_URL = File.join(Rails.configuration.x.api.root_url, "projects").freeze
 
   STATUS = {
     in_progress: 1,

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -1,7 +1,7 @@
 class Trust
   include ActiveModel::Model
 
-  SEARCH_URL = "https://academy-transfers-prototype-api.london.cloudapps.digital/trusts".freeze
+  SEARCH_URL = File.join(Rails.configuration.x.api.root_url, "trusts").freeze
 
   attr_accessor :id, :trust_name, :companies_house_number, :trust_reference_number, :address,
                 :establishment_type, :establishment_type_group, :ukprn, :upin

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,7 @@ module GovukRailsBoilerplate
     Rails.configuration.x.api.client_scope = ENV.fetch("API_CLIENT_SCOPE", api_credentials[:client_scope])
     Rails.configuration.x.api.client_id = ENV.fetch("API_CLIENT_ID", api_credentials[:client_id])
     Rails.configuration.x.api.client_secret = ENV.fetch("API_CLIENT_SECRET", api_credentials[:client_secret])
+    Rails.configuration.x.api.root_url = ENV.fetch("API_ROOT_URL", "https://academy-transfers-prototype-api.london.cloudapps.digital")
 
     # Authentication credentials
     default_user_credentials = Rails.application.credentials.default_user || {}


### PR DESCRIPTION
### Context
API root had been hard coded. By allowing it to be set via an environment variable it is possible to match the API locations for each server instance and environment.

### Changes proposed in this pull request
- Define API root URL in /config/application.rb with override via ENV
- Update models to use this URL root

