### PR TITLE
Display breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "devise"
 # Redis data store used for caching
 gem "redis"
 
+# Manage breadcrumbs
+gem "loaf"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     listen (3.3.4)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    loaf (0.10.0)
+      railties (>= 3.2)
     loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -126,12 +128,16 @@ GEM
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.0)
     minitest (5.14.3)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.4)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.4)
@@ -314,6 +320,7 @@ DEPENDENCIES
   faraday
   foreman
   listen (>= 3.0.5, < 3.4)
+  loaf
   oauth2
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,7 @@
 class DashboardController < ApplicationController
   before_action :authenticate_user!
 
+  breadcrumb :dashboard, :root_path
+
   def index; end
 end

--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -1,4 +1,6 @@
 class IncomingTrustsController < ApplicationController
+  before_action :authenticate_user!
+
   def index; end
 
   def create

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,6 @@
 class ProjectsController < ApplicationController
+  before_action :authenticate_user!
+
   # POST /trusts/:trust_id/projects
   def create
     @project = Project.new(project_params)

--- a/app/controllers/trusts_controller.rb
+++ b/app/controllers/trusts_controller.rb
@@ -1,6 +1,9 @@
 class TrustsController < ApplicationController
   before_action :authenticate_user!
 
+  breadcrumb :dashboard, :root_path
+  breadcrumb :add_new_project, :trusts_path
+
   # GET /trusts
   def index; end
 
@@ -19,5 +22,6 @@ class TrustsController < ApplicationController
   # GET /trusts/1
   def show
     @trust = Trust.find(params[:id])
+    breadcrumb :trust_details, trust_path(@trust.id)
   end
 end

--- a/app/views/application/_breadcrumbs.html.erb
+++ b/app/views/application/_breadcrumbs.html.erb
@@ -1,0 +1,13 @@
+<% if breadcrumb_trail.to_a.present? %>
+  <div class="govuk-breadcrumbs ">
+    <ol class="govuk-breadcrumbs__list">
+      <% breadcrumb_trail do |crumb| %>
+        <li class="govuk-breadcrumbs__list-item">
+          <%= link_to crumb.name, crumb.url, class: "govuk-breadcrumbs__link", data: { turbolinks: false } %>
+        </li>
+      <% end %>
+    </ol>
+  </div>
+<% else %>
+  <%= link_to t("generic.back"), :back, class: "govuk-back-link" %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,7 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper " id="main-content" role="main">
+        <%= render "breadcrumbs" %>
         <%= render "flash_notice", notice: notice if notice %>
         <%= render "flash_alert", alert: alert if alert %>
         <%= yield %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,4 +104,5 @@ en:
   generic:
     yes: Yes
     no: No
+    back: Back
       

--- a/config/locales/loaf.en.yml
+++ b/config/locales/loaf.en.yml
@@ -1,0 +1,8 @@
+en:
+  loaf:
+    errors:
+      invalid_options: "Invalid option :%{invalid}. Valid options are: %{valid}, make sure these are the ones you are using."
+    breadcrumbs:
+      dashboard: Academy Transfer Dashboard
+      add_new_project: Add new project
+      trust_details: Trust details


### PR DESCRIPTION
### Context
Breadcrumbs: display list of previous page links above page title to allow users to return to previous steps in the journey

### Changes proposed in this pull request
- Add to pages where present in prototype
- Display Back link where no breadcrumbs (as in prototype)
- Use [loaf gem](https://github.com/piotrmurach/loaf) to manage breadcrumbs

Also fixes bug where some controllers weren't protected by authentication

### Guidance to review
This is how the changes appear of the page
#### Page with breadcrumbs
![breadcrumbs](https://user-images.githubusercontent.com/213040/105044352-89304600-5a5e-11eb-8d7a-b4235c0b3a58.png)

#### Page with back link
![back_link](https://user-images.githubusercontent.com/213040/105044381-90575400-5a5e-11eb-8ce8-83c2ceab788b.png)
