### PR TITLE
Update trust identified page to store user response and continue

### DIFF
--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -4,11 +4,9 @@ class IncomingTrustsController < ApplicationController
   def index; end
 
   def create
-    case params[:trust_identified]
-    when "yes"
+    if trust_identified
+      session_store.set :incoming_trust_identified, trust_identified
       redirect_to identified_trust_incoming_trusts_path(outgoing_trust_id)
-    when "no"
-      render plain: "Redirect to page not build yet"
     else
       @error = I18n.t("errors.must_select_yes_or_no")
       render :index
@@ -42,5 +40,9 @@ private
 
   def outgoing_trust_id
     @outgoing_trust_id = params[:trust_id]
+  end
+
+  def trust_identified
+    params[:trust_identified]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,16 +4,15 @@ module ApplicationHelper
   end
 
   def tab_link(name, selected: false)
-    classes = ["govuk-tabs__list-item"]
+    classes = %w[govuk-tabs__list-item]
     classes << "govuk-tabs__list-item--selected" if selected
 
-    link = link_to(t(".tab_headers.#{name}"), "##{name}", class: "govuk-tabs__tab", id: "tab_#{name}"
-    )
+    link = link_to t(".tab_headers.#{name}"), "##{name}", class: "govuk-tabs__tab", id: "tab_#{name}"
 
-    content_tag(:li, link, class: classes)
+    tag.li(link, class: classes)
   end
 
   def render_as_tab(name, *args)
-    content_tag :div, render(name.to_s *args), id: name, class: "govuk-tabs__panel"
+    tag.div(render(name.to_s(*args)), id: name, class: "govuk-tabs__panel")
   end
 end

--- a/spec/requests/incoming_trusts_spec.rb
+++ b/spec/requests/incoming_trusts_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "IncomingTrusts", type: :request do
   let(:trust) { build :trust }
   let(:outgoing_trust) { trust }
   let(:incoming_trust) { build :trust }
+  let(:session_store) { SessionStore.new(user, trust.id) }
   let(:user) { create :user }
 
   before { sign_in user }
@@ -27,12 +28,22 @@ RSpec.describe "IncomingTrusts", type: :request do
       expect(response).to redirect_to(identified_trust_incoming_trusts_path(trust.id))
     end
 
+    it "records choice in session_store" do
+      subject
+      expect(session_store.get(:incoming_trust_identified)).to eq(trust_identified)
+    end
+
     context "when no trust identified" do
       let(:trust_identified) { "no" }
 
-      xit "redirects to ..." do
+      it "redirects to identified" do
         subject
-        expect(response).to redirect_to(:tbc)
+        expect(response).to redirect_to(identified_trust_incoming_trusts_path(trust.id))
+      end
+
+      it "records choice in session_store" do
+        subject
+        expect(session_store.get(:incoming_trust_identified)).to eq(trust_identified)
       end
     end
 
@@ -91,7 +102,6 @@ RSpec.describe "IncomingTrusts", type: :request do
   end
 
   describe "GET /trusts/:trust_id/incoming/:id" do
-    let(:session_store) { SessionStore.new(user, trust.id) }
     let(:academy) { build :academy }
 
     before do


### PR DESCRIPTION
### Context
Currently selecting "No" to "Has an incoming trust been identified?" led to a holding page. The intention was to redirect to a summary page.

Following discussions it was realised that the information displayed on the summary still needed some information about the incoming trusts being considered. So, this action needs to store the response, but still go to the page to identify incoming trusts.

### Changes proposed in this pull request

Change the behaviour so that the user is redirected to the select incoming trusts page if they answer "yes" or "no" and store the response in the Session Store.

Also included is an update to the application helper to resolve a rubocop issue.
