### PR TITLE
Add "Save and Add" to the incoming trust selection to allow multiple trusts to be identified

### DIFF
--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -35,6 +35,13 @@ class IncomingTrustsController < ApplicationController
     end
   end
 
+  def destroy
+    if incoming_trust_ids.delete(params[:id])
+      session_store.set :incoming_trust_ids, incoming_trust_ids
+    end
+    redirect_to(identified_trust_incoming_trusts_path(outgoing_trust_id))
+  end
+
   def show
     @outgoing_trust = Trust.find(outgoing_trust_id)
     @academies = Academy.belonging_to_trust(@outgoing_trust.id).select { |academy| selected_academy_ids.include?(academy.id) }
@@ -80,7 +87,7 @@ private
   end
 
   def search_error
-    @search_error = I18n.t("errors.trust.empty_search_error") if search_input.empty? && incoming_trust_ids.empty?
+    @search_error = I18n.t("errors.trust.empty_search_error") if search_input.blank? && incoming_trust_ids.empty?
   end
 
   def search_input

--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -13,16 +13,29 @@ class IncomingTrustsController < ApplicationController
     end
   end
 
-  def identified; end
+  def identified
+    incoming_trusts
+  end
 
   def search
-    @trusts = Trust.search(params["input-autocomplete"])
+    @trusts = search_result
 
-    redirect_to trust_incoming_trust_path(outgoing_trust_id, @trusts.first.id) if @trusts.one?
+    return render :search unless @trusts.one? || empty_search?
+
+    if @trusts.present?
+      incoming_trust_ids << @trusts.first.id unless incoming_trust_ids.include?(@trusts.first.id)
+      session_store.set :incoming_trust_ids, incoming_trust_ids
+    end
+
+    if search_error || add_trust_selected?
+      incoming_trusts
+      render :identified
+    else
+      redirect_to trust_incoming_trust_path(outgoing_trust_id, incoming_trust_ids.first)
+    end
   end
 
   def show
-    session_store.set :incoming_trusts, [params[:id]]
     @outgoing_trust = Trust.find(outgoing_trust_id)
     @academies = Academy.belonging_to_trust(@outgoing_trust.id).select { |academy| selected_academy_ids.include?(academy.id) }
     @incoming_trust = Trust.find(params[:id])
@@ -44,5 +57,39 @@ private
 
   def trust_identified
     params[:trust_identified]
+  end
+
+  def incoming_trusts
+    @incoming_trusts ||= incoming_trust_ids.map { |trust_id| Trust.find(trust_id) }
+  end
+
+  def incoming_trust_ids
+    @incoming_trust_ids ||= session_store.get(:incoming_trust_ids) || []
+  end
+
+  def identified_scope
+    "incoming_trusts.identified"
+  end
+
+  def add_trust_selected?
+    params[:commit] == I18n.t(:add_trust, scope: identified_scope)
+  end
+
+  def empty_search?
+    search_input.blank?
+  end
+
+  def search_error
+    @search_error = I18n.t("errors.trust.empty_search_error") if search_input.empty? && incoming_trust_ids.empty?
+  end
+
+  def search_input
+    params["input-autocomplete"]
+  end
+
+  def search_result
+    return [] if empty_search?
+
+    Trust.search(search_input)
   end
 end

--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -38,7 +38,7 @@ class IncomingTrustsController < ApplicationController
   def show
     @outgoing_trust = Trust.find(outgoing_trust_id)
     @academies = Academy.belonging_to_trust(@outgoing_trust.id).select { |academy| selected_academy_ids.include?(academy.id) }
-    @incoming_trust = Trust.find(params[:id])
+    incoming_trusts
   end
 
 private

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -13,6 +13,8 @@ class Trust
         response = Faraday.get(SEARCH_URL, search: content) do |req|
           req.headers["Authorization"] = "Bearer #{token}"
         end
+        raise "API call to /trusts to search for \"#{content}\" failed with: #{response.body}" unless response.success?
+
         response.body
       end
       payload = JSON.parse(payload)

--- a/app/services/model_cache.rb
+++ b/app/services/model_cache.rb
@@ -4,7 +4,9 @@ module ModelCache
   extend RedisMethods
 
   def self.set(model)
-    redis.set key_for(model.id), model.to_json
+    redis_key = key_for(model.id)
+    redis.set redis_key, model.to_json
+    redis.expire(redis_key, EXPIRY)
   end
 
   def self.get(model_id)

--- a/app/services/model_cache.rb
+++ b/app/services/model_cache.rb
@@ -1,0 +1,20 @@
+module ModelCache
+  EXPIRY = 5.minutes
+
+  extend RedisMethods
+
+  def self.set(model)
+    redis.set key_for(model.id), model.to_json
+  end
+
+  def self.get(model_id)
+    data = redis.get(key_for(model_id))
+    return unless data
+
+    JSON.parse(data)
+  end
+
+  def self.key_for(uuid)
+    [Rails.env, "model_cache", uuid].join("_")
+  end
+end

--- a/app/views/incoming_trusts/identified.html.erb
+++ b/app/views/incoming_trusts/identified.html.erb
@@ -6,18 +6,18 @@
   <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 </div>
 
-
 <table class="govuk-table">
   <tbody class="govuk-table__body">
     <% @incoming_trusts.each do |incoming_trust| %>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header"><%= incoming_trust.label %></th>
-        <td class="govuk-table__cell">Remove</td>
+        <td class="govuk-table__cell">
+          <%= link_to t(".remove_trust"), trust_incoming_trust_path(params[:trust_id], incoming_trust.id), method: :delete %>
+        </td>
       </tr>
     <% end %>
   </tbody>
 </table>
-
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/incoming_trusts/identified.html.erb
+++ b/app/views/incoming_trusts/identified.html.erb
@@ -1,9 +1,20 @@
 <% content_for(:page_header) { t(".page_header") } %>
 
+<%= render("error_summary", errors: [@search_error]) if @search_error %>
+
 <div class="govuk-width-container"><br>
   <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 </div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <ul>
+      <% @incoming_trusts.each do |incoming_trust| %>
+        <li><%= incoming_trust.label %></li>
+      <% end %>
+    </ul>
+  </div>
+</div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -13,7 +24,15 @@
         <%= form.label :autocomplete_trusts, t(".search_label"), class: "govuk-hint" %>
         <div id="autocomplete_trusts"></div>
       </div>
-      <%= form.submit t(".search_button"), class: "govuk-button" %>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <%= form.submit t(".add_trust"), class: "govuk-button govuk-button--secondary" %>
+        </div>
+        <div class="govuk-grid-column-one-half align-right">
+          <%= form.submit t(".search_button"), class: "govuk-button" %>
+        </div>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/incoming_trusts/identified.html.erb
+++ b/app/views/incoming_trusts/identified.html.erb
@@ -6,15 +6,18 @@
   <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <ul>
-      <% @incoming_trusts.each do |incoming_trust| %>
-        <li><%= incoming_trust.label %></li>
-      <% end %>
-    </ul>
-  </div>
-</div>
+
+<table class="govuk-table">
+  <tbody class="govuk-table__body">
+    <% @incoming_trusts.each do |incoming_trust| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= incoming_trust.label %></th>
+        <td class="govuk-table__cell">Remove</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/incoming_trusts/search.html.erb
+++ b/app/views/incoming_trusts/search.html.erb
@@ -8,7 +8,18 @@
   <div class="govuk-grid-column-two-thirds">
     <ul>
     <% @trusts.each do |trust| %>
-      <li><%= link_to trust.trust_name, trust_incoming_trust_path(params[:trust_id], trust.id) %></li>
+      <li>
+        <%=
+            link_to(
+                trust.trust_name,
+                search_trust_incoming_trusts_path(
+                  params[:trust_id],
+                  "input-autocomplete" => trust.trust_name,
+                  commit: t("incoming_trusts.identified.add_trust")
+                )
+             )
+        %>
+      </li>
     <% end %>
   </div>
 </div>

--- a/app/views/incoming_trusts/show.html.erb
+++ b/app/views/incoming_trusts/show.html.erb
@@ -46,28 +46,30 @@
 <div class="govuk-width-container">
   <h2 class="govuk-heading-m"><%= t(".incoming_trusts") %></h2>
 
-  <dl class="govuk-summary-list">
-    <% [
-         :trust_name,
-         :companies_house_number,
-         :trust_reference_number,
-         :establishment_type
-       ].each do |attribute| %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
-        <dd class="govuk-summary-list__value"><%= @incoming_trust.send(attribute) %></dd>
-      </div>
-    <% end %>
+  <% @incoming_trusts.each do |incoming_trust| %>
+    <dl class="govuk-summary-list">
+      <% [
+           :trust_name,
+           :companies_house_number,
+           :trust_reference_number,
+           :establishment_type
+         ].each do |attribute| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
+          <dd class="govuk-summary-list__value"><%= incoming_trust.send(attribute) %></dd>
+        </div>
+      <% end %>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key"><%= t(".address") %></dt>
-      <dd class="govuk-summary-list__value">
-        <% @incoming_trust.address.split(/[\n\r$\,]+/).each do |address_line| %>
-          <p class="govuk-body"><%= address_line %></p>
-        <% end %>
-      </dd>
-    </div>
-  </dl>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".address") %></dt>
+        <dd class="govuk-summary-list__value">
+          <% incoming_trust.address.split(/[\n\r$\,]+/).each do |address_line| %>
+            <p class="govuk-body"><%= address_line %></p>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+  <% end %>
 </div>
 
 <div class="govuk-width-container">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -10,4 +10,6 @@ Rails.start();
 Turbolinks.start();
 initAll();
 
-autocompleteSelection('#autocomplete_trusts', '/trusts/search.json');
+document.addEventListener('turbolinks:load', () => {
+  autocompleteSelection('#autocomplete_trusts', '/trusts/search.json');
+});

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -15,3 +15,7 @@ $govuk-image-url-function: frontend-image-url;
 .sign-out {
   float: right;
 }
+
+.align-right {
+  text-align: right;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
       search_label: Search by name, trust reference number or companies house number
       search_button: Save and continue
       add_trust: Save and Add
+      remove_trust: Remove
     search:
       page_header: Transfer an academy to another trust
       heading: Select incoming trust

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
       page_header: Transfer an academy to another trust
       heading: Add the incoming trust name
       search_label: Search by name, trust reference number or companies house number
-      search_button: Search and continue
+      search_button: Save and continue
       add_trust: Save and Add
     search:
       page_header: Transfer an academy to another trust

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
       heading: Add the incoming trust name
       search_label: Search by name, trust reference number or companies house number
       search_button: Search and continue
+      add_trust: Save and Add
     search:
       page_header: Transfer an academy to another trust
       heading: Select incoming trust
@@ -99,6 +100,7 @@ en:
     summary: There is a problem
     trust:
       no_academy_selected: An academy must be selected
+      empty_search_error: Please entry the name of a trust
     must_select_yes_or_no: Yes or No must be selected
 
   generic:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :trusts, only: %i[index show] do
     get :search, on: :collection
     resources :academies, only: %i[index create]
-    resources :incoming_trusts, only: %i[index show create], path: :incoming do
+    resources :incoming_trusts, only: %i[index show create destroy], path: :incoming do
       collection do
         get :identified
         get :search

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -3,7 +3,7 @@ namespace :lint do
   desc "Ruby lint via rubocop"
   task ruby: :environment do
     puts "Linting ruby..."
-    system "bundle exec rubocop app config db lib spec Gemfile --format clang -a"
+    system "bundle exec rubocop app config db lib spec Gemfile --format clang"
   end
 
   desc "SCSS lint"

--- a/spec/models/trust_spec.rb
+++ b/spec/models/trust_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Trust, type: :model do
       # JSON response is cached so mismatch between keys (camelcase in JSON), so just checking trust id within cached data
       expect(redis.get(redis_key)).to include(trust.id)
     end
+
+    it "caches model in redis" do
+      results
+      key = ModelCache.key_for(trust.id)
+      expect(redis.get(key)).to eq(trust.to_json)
+    end
   end
 
   describe ".find" do
@@ -35,6 +41,22 @@ RSpec.describe Trust, type: :model do
 
     it "returns the trust" do
       expect(result.as_json).to eq(trust.as_json)
+    end
+
+    context "trust is cached" do
+      let(:cached_trust) { build :trust, id: trust.id }
+      before { ModelCache.set(cached_trust) }
+
+      it "returns the cached trust" do
+        expect(result.as_json).not_to eq(trust.as_json)
+        expect(result.as_json).to eq(cached_trust.as_json)
+      end
+    end
+  end
+
+  describe "#label" do
+    it "contains name, identifiers" do
+      expect(trust.label).to eq("#{trust.trust_name}, #{trust.trust_reference_number}, #{trust.companies_house_number}")
     end
   end
 end

--- a/spec/requests/incoming_trusts_spec.rb
+++ b/spec/requests/incoming_trusts_spec.rb
@@ -205,4 +205,29 @@ RSpec.describe "IncomingTrusts", type: :request do
       expect(response.body).to include(academy.urn)
     end
   end
+
+  describe "DELETE /trusts/:trust_id/incoming/:id" do
+    subject { delete trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id) }
+
+    it "Redirects to the search page" do
+      subject
+      expect(response).to redirect_to(identified_trust_incoming_trusts_path(outgoing_trust.id))
+    end
+
+    context "incoming trust is present in session store" do
+      before do
+        session_store.set :incoming_trust_ids, [incoming_trust.id]
+      end
+
+      it "Removed the incoming trust id from session store" do
+        subject
+        expect(session_store.get(:incoming_trust_ids)).not_to include(incoming_trust.id)
+      end
+
+      it "Redirects to the search page" do
+        subject
+        expect(response).to redirect_to(identified_trust_incoming_trusts_path(outgoing_trust.id))
+      end
+    end
+  end
 end

--- a/spec/requests/incoming_trusts_spec.rb
+++ b/spec/requests/incoming_trusts_spec.rb
@@ -112,14 +112,21 @@ RSpec.describe "IncomingTrusts", type: :request do
       let(:query) { Faker::Educator.secondary_school }
       let(:trusts) { build_list :trust, 2, trust_name: query }
       let(:incoming_trust) { trusts.first }
+      let(:link_back_to_search) do
+        search_trust_incoming_trusts_path(
+          outgoing_trust.id,
+          "input-autocomplete" => incoming_trust.trust_name,
+          commit: I18n.t("incoming_trusts.identified.add_trust"),
+        )
+      end
 
       it "Renders successfully" do
         expect(response).to be_successful
       end
 
-      it "displays link to incoming trust's show page" do
+      it "displays link back to search with trust name as input" do
         expect(response.body).to include(incoming_trust.trust_name)
-        expect(response.body).to include(trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id))
+        expect(response.body).to include(CGI.escapeHTML(link_back_to_search))
       end
 
       it "renders search template" do
@@ -178,6 +185,7 @@ RSpec.describe "IncomingTrusts", type: :request do
       mock_trust_find(incoming_trust)
       mock_trust_find(outgoing_trust)
       session_store.set :academy_ids, [academy.id]
+      session_store.set :incoming_trust_ids, [incoming_trust.id]
       get trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id)
     end
 

--- a/spec/requests/incoming_trusts_spec.rb
+++ b/spec/requests/incoming_trusts_spec.rb
@@ -63,9 +63,23 @@ RSpec.describe "IncomingTrusts", type: :request do
   end
 
   describe "GET /trust/:trust_id/incoming/identified" do
+    subject { get identified_trust_incoming_trusts_path(trust.id) }
+
     it "returns http success" do
-      get identified_trust_incoming_trusts_path(trust.id)
+      subject
       expect(response).to have_http_status(:success)
+    end
+
+    context "when incoming trust already added" do
+      before do
+        session_store.set :incoming_trust_ids, [incoming_trust.id]
+        ModelCache.set(incoming_trust)
+        subject
+      end
+
+      it "displays trust" do
+        expect(response.body).to include(incoming_trust.trust_name)
+      end
     end
   end
 
@@ -74,11 +88,20 @@ RSpec.describe "IncomingTrusts", type: :request do
     let(:trusts) { [incoming_trust] }
     let(:redis) { Redis.new }
     let(:redis_key) { "test_block_cache_trusts_#{query}" }
+    let(:submit_button) { :search_button }
+    let(:previously_saved) { [] }
+    let(:params) do
+      {
+        "input-autocomplete" => query,
+        "commit" => I18n.t("incoming_trusts.identified.#{submit_button}"),
+      }
+    end
 
     before do
       redis.del(redis_key)
       mock_trust_search(query, trusts)
-      get search_trust_incoming_trusts_url(outgoing_trust.id), params: { "input-autocomplete" => query }
+      session_store.set :incoming_trust_ids, previously_saved
+      get search_trust_incoming_trusts_url(outgoing_trust.id), params: params
     end
 
     it "Redirects to show for single result" do
@@ -90,13 +113,59 @@ RSpec.describe "IncomingTrusts", type: :request do
       let(:trusts) { build_list :trust, 2, trust_name: query }
       let(:incoming_trust) { trusts.first }
 
-      it "renders a successful response" do
+      it "Renders successfully" do
         expect(response).to be_successful
       end
 
       it "displays link to incoming trust's show page" do
         expect(response.body).to include(incoming_trust.trust_name)
         expect(response.body).to include(trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id))
+      end
+
+      it "renders search template" do
+        expect(response.body).to include(I18n.t("incoming_trusts.search.heading"))
+      end
+    end
+
+    context "when Add button submitted" do
+      let(:submit_button) { :add_trust }
+
+      it "Renders successfully" do
+        expect(response).to be_successful
+      end
+
+      it "stores incoming trust in session store" do
+        expect(session_store.get(:incoming_trust_ids)).to eq([incoming_trust.id])
+      end
+
+      it "renders identified template" do
+        expect(response.body).to include(I18n.t("incoming_trusts.identified.heading"))
+      end
+    end
+
+    context "when nothing entered" do
+      let(:query) { "" }
+
+      it "Renders successfully" do
+        expect(response).to be_successful
+      end
+
+      it "displays error" do
+        expect(response.body).to include(I18n.t("errors.trust.empty_search_error"))
+      end
+
+      it "renders identified template" do
+        expect(response.body).to include(I18n.t("incoming_trusts.identified.heading"))
+      end
+    end
+
+    context "when nothing entered, and incoming trusts already added" do
+      let(:query) { "" }
+      let(:trusts) { [] }
+      let(:previously_saved) { [incoming_trust.id] }
+
+      it "Redirects to show for single result" do
+        expect(response).to redirect_to(trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id))
       end
     end
   end

--- a/spec/services/model_cache_spec.rb
+++ b/spec/services/model_cache_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ModelCache do
+  let(:trust) { build :trust }
+  let(:redis) { described_class.redis }
+  let(:redis_key) { "test_model_cache_#{trust.id}" }
+
+  before { redis.del(redis_key) }
+
+  describe ".set" do
+    it "caches the model" do
+      described_class.set(trust)
+      expect(redis.get(redis_key)).to eq(trust.to_json)
+    end
+  end
+
+  describe ".get" do
+    it "returns nil" do
+      expect(described_class.get(trust.id)).to be_nil
+    end
+
+    context "when a model is cached" do
+      it "returns the model data" do
+        described_class.set(trust)
+        expect(described_class.get(trust.id)).to eq(trust.as_json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
The user also needs to be able to remove trusts added via "Save and Add"

### Changes proposed in this pull request

- Add second commit button for "Save and Add"
- Add `ModelCache` to cache instance data
- Cache trust model instances so no 2nd API call to display name etc.
- Add error if form submitted but no trust identified
- Add `trust#label` to display short descriptive summary
- Display saved trusts in identified view
- Update incoming_trusts#show to display all selected trusts
- Expire model cache
- Put list of incoming trusts in table
- Change links in search partial to return to search with selected trust
- Raise error if call to search API fails to aid debugging
- Add incoming_trusts#destroy action
- Ensure autocomplete JavaScript is reloaded on Turbolinks partial page load

### Guidance to review
With these changes the add incoming trusts pages looks like this:

![save_and_add_multiple_incoming_trusts](https://user-images.githubusercontent.com/213040/105388291-647ad080-5c0e-11eb-98fa-7a8d6647cdd1.png)