### PR TITLE
Add change links to summary page

### DIFF
--- a/app/controllers/academies_controller.rb
+++ b/app/controllers/academies_controller.rb
@@ -4,6 +4,7 @@ class AcademiesController < ApplicationController
   # GET /academies
   def index
     academies
+    academy_ids
   end
 
   # POST /academies
@@ -14,6 +15,7 @@ class AcademiesController < ApplicationController
     else
       @error = I18n.t("errors.trust.no_academy_selected")
       academies
+      academy_ids
       render :index
     end
   end
@@ -30,5 +32,9 @@ private
 
   def academy_data
     @academy_data ||= params.dig(:trust, :academy_ids).select(&:present?)
+  end
+
+  def academy_ids
+    @academy_ids ||= session_store.get(:academy_ids) || []
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,21 @@ module ApplicationHelper
   def render_as_tab(name, *args)
     tag.div(render(name.to_s(*args)), id: name, class: "govuk-tabs__panel")
   end
+
+  def summary_row(model, attribute, change_url: nil)
+    title = tag.dt(t(".#{attribute}"), class: "govuk-summary-list__key")
+    value = tag.dd(model.send(attribute), class: "govuk-summary-list__value")
+
+    change_link = change_url ? link_to_change(model.class.name, change_url) : ""
+    change = tag.dd(change_link, class: "govuk-summary-list__actions")
+
+    tag.div(class: "govuk-summary-list__row") do
+      [title, value, change].each { |e| safe_concat(e) }
+    end
+  end
+
+  def link_to_change(label, url)
+    hidden_span = tag.span(label, class: "govuk-visually-hidden")
+    link_to("#{t('generic.change')} #{hidden_span}".html_safe, url, class: "govuk-link")
+  end
 end

--- a/app/views/academies/index.html.erb
+++ b/app/views/academies/index.html.erb
@@ -16,7 +16,8 @@
       <div class="govuk-checkboxes">
         <%= collection_check_boxes(:trust, :academy_ids, @academies, :id, :academy_name_with_urn) do |element| %>
           <div class="govuk-checkboxes__item">
-            <%= element.check_box(class: "govuk-checkboxes__input") %>
+            <% checked = @academy_ids.include?(element.object.id) %>
+            <%= element.check_box(class: "govuk-checkboxes__input", checked: checked) %>
             <%= element.label(class: "govuk-label govuk-checkboxes__label") %>
           </div>
         <% end %>

--- a/app/views/incoming_trusts/show.html.erb
+++ b/app/views/incoming_trusts/show.html.erb
@@ -7,15 +7,8 @@
 <div class="govuk-width-container">
   <h2 class="govuk-heading-m"><%= t(".outgoing_trust") %></h2>
   <dl class="govuk-summary-list">
-    <% [
-         :trust_name,
-         :trust_reference_number
-       ].each do |attribute| %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
-        <dd class="govuk-summary-list__value"><%= @outgoing_trust.send(attribute) %></dd>
-      </div>
-    <% end %>
+    <%= summary_row(@outgoing_trust, :trust_name, change_url: trusts_path) %>
+    <%= summary_row(@outgoing_trust, :trust_reference_number) %>
   </dl>
 </div>
 
@@ -24,8 +17,8 @@
 
   <% @academies.each do |academy| %>
     <dl class="govuk-summary-list">
+      <%= summary_row(academy, :academy_name, change_url: trust_academies_path(@outgoing_trust.id)) %>
       <% [
-         :academy_name,
          :urn,
          :local_authority_name,
          :establishment_type,
@@ -34,10 +27,7 @@
          :ofsted_inspection_date_formatted,
          :pfi
        ].each do |attribute| %>
-          <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
-          <dd class="govuk-summary-list__value"><%= academy.send(attribute) %></dd>
-        </div>
+        <%= summary_row academy, attribute %>
       <% end %>
     </dl>
   <% end %>
@@ -48,16 +38,13 @@
 
   <% @incoming_trusts.each do |incoming_trust| %>
     <dl class="govuk-summary-list">
+      <%= summary_row(incoming_trust, :trust_name, change_url: identified_trust_incoming_trusts_path(@outgoing_trust.id)) %>
       <% [
-           :trust_name,
            :companies_house_number,
            :trust_reference_number,
            :establishment_type
          ].each do |attribute| %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><%= t(".#{attribute}") %></dt>
-          <dd class="govuk-summary-list__value"><%= incoming_trust.send(attribute) %></dd>
-        </div>
+        <%= summary_row(incoming_trust, attribute) %>
       <% end %>
 
       <div class="govuk-summary-list__row">
@@ -67,6 +54,7 @@
             <p class="govuk-body"><%= address_line %></p>
           <% end %>
         </dd>
+        <dd class="govuk-summary-list__actions"></dd>
       </div>
     </dl>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,28 @@
 en:
   default_page_header: Academy Transfers
 
+  models:
+    trust: &trust_attributes
+      trust_name: Name
+      companies_house_number: Companies House Number
+      establishment_type: Type
+      trust_reference_number: Trust Reference Number
+      address: Address
+    academy: &academy_attributes
+      academy_name: Name
+      urn: URN
+      address: Address
+      establishment_type: School type
+      local_authority_number: Local Authority Number
+      local_authority_name: Local Authority
+      religious_character: Faith School
+      diocese_name: Diocese Name
+      religious_ethos: Religious Ethos
+      ofsted_rating: Ofsted Rating
+      ofsted_inspection_date: Last inspection
+      ofsted_inspection_date_formatted: Last inspection
+      pfi: PFI (private finance initiative)
+
   academies:
     index:
       page_header: Transfer an academy to another trust
@@ -78,6 +100,8 @@ en:
       academy_details: Academy details
       incoming_trusts: Incoming trusts
       next_action_link: Save and continue
+      <<: *trust_attributes
+      <<: *academy_attributes
   trusts:
     index:
       page_header: Transfer an academy to another trust
@@ -90,11 +114,7 @@ en:
     show:
       page_header: Transfer an academy to another trust
       heading: Outgoing trust details
-      trust_name: Name
-      companies_house_number: Companies House Number
-      establishment_type: Type
-      trust_reference_number: Trust Reference Number
-      address: Address
+      <<: *trust_attributes
       next_action_link: Select Trust
 
   errors:
@@ -108,4 +128,5 @@ en:
     yes: Yes
     no: No
     back: Back
+    change: Change
       


### PR DESCRIPTION
### Context
Links on the summary page allow a user to return to earlier parts of their journey to change selected trusts and academies.

Note: the behaviour here mirrors that in the prototype in that on selecting the change link the user is returned to the previous part of the journey and then has to complete the subsequent parts of the journey again.

### Changes proposed in this pull request
- Add summary_row helper to aid adding change links to some rows
- Update academies#index to check previously selected academies
- Update translation files to include model attributes

### Guidance to review
The summary page with this change looks like this:
![summary_page_with_links](https://user-images.githubusercontent.com/213040/105513648-7c178f00-5cca-11eb-85fd-9aa56642b6a9.png)

