### PR TITLE
Update Projects controller to use new session store key for incoming trust ids

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,7 +21,7 @@ private
       project_status: Project::STATUS[:in_progress],
       academy_ids: session_store.get(:academy_ids),
       outgoing_trust_id: params[:trust_id],
-      incoming_trust_id: session_store.get(:incoming_trusts).first,
+      incoming_trust_id: session_store.get(:incoming_trust_ids).first,
     }
   end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "/projects", type: :request do
     before do
       sign_in user
       session_store.set(:academy_ids, [academy.id])
-      session_store.set(:incoming_trusts, [incoming_trust.id])
+      session_store.set(:incoming_trust_ids, [incoming_trust.id])
       mock_project_save(project, response_body)
     end
     subject { post trust_projects_path(outgoing_trust.id) }


### PR DESCRIPTION
### Context
The session store key for incoming trust ids was recently changed to `:incoming_trust_ids`, but the Projects controller had not been updated to match, causing an error. The PR corrects that issue.

