### PR TITLE
Add Dashboard Project lists

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,5 +3,8 @@ class DashboardController < ApplicationController
 
   breadcrumb :dashboard, :root_path
 
-  def index; end
+  def index
+    @in_progress_projects = Project.in_progress(ascending: false, page_size: 5)
+    @completed_projects = Project.completed(ascending: false, page_size: 5)
+  end
 end

--- a/app/models/academy.rb
+++ b/app/models/academy.rb
@@ -7,11 +7,8 @@ class Academy
 
   class << self
     def belonging_to_trust(trust_id)
-      token = BearerToken.token
       url = File.join(Trust::SEARCH_URL, trust_id, "academies")
-      response = Faraday.get(url) do |req|
-        req.headers["Authorization"] = "Bearer #{token}"
-      end
+      response = Api.get(url)
       payload = JSON.parse(response.body)
       payload.map { |input| new(input) }
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,10 +26,7 @@ class Project
                 :rdd_or_rsc_intervention_reasons_explained, :academy_ids, :outgoing_trust_id, :incoming_trust_id
 
   def save
-    token = BearerToken.token
-    Faraday.post(SAVE_URL, api_payload.to_json, "Content-Type" => "application/json") do |req|
-      req.headers["Authorization"] = "Bearer #{token}"
-    end
+    Api.post(SAVE_URL, api_payload)
   end
 
   def api_payload

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,7 @@
 class Project
   include ActiveModel::Model
 
-  SAVE_URL = File.join(Rails.configuration.x.api.root_url, "projects").freeze
+  PROJECTS_URL = File.join(Rails.configuration.x.api.root_url, "projects").freeze
 
   STATUS = {
     in_progress: 1,
@@ -25,8 +25,30 @@ class Project
                 :esfa_intervention_reasons, :esfa_intervention_reasons_explained, :rdd_or_rsc_intervention_reasons,
                 :rdd_or_rsc_intervention_reasons_explained, :academy_ids, :outgoing_trust_id, :incoming_trust_id
 
+  class << self
+    def completed(args = {})
+      search(args.merge(status: STATUS[:completed]))
+    end
+
+    def in_progress(args = {})
+      search(args.merge(status: STATUS[:in_progress]))
+    end
+
+    def search(args = {})
+      query = args.transform_keys { |key| key.to_s.camelize(:lower) }
+      response = Api.get(PROJECTS_URL, query)
+      data = JSON.parse(response.body)
+      data["projects"].map { |project_data| new(project_data) }
+    end
+  end
+
+  def initialize(attributes = {})
+    attributes.transform_keys! { |key| key.to_s.underscore }
+    super
+  end
+
   def save
-    Api.post(SAVE_URL, api_payload)
+    Api.post(PROJECTS_URL, api_payload)
   end
 
   def api_payload
@@ -54,5 +76,9 @@ class Project
         ],
       }
     end
+  end
+
+  def status_key
+    STATUS.invert[project_status]
   end
 end

--- a/app/models/trust.rb
+++ b/app/models/trust.rb
@@ -8,11 +8,8 @@ class Trust
 
   class << self
     def search(content)
-      token = BearerToken.token
       payload = BlockCache.with(content, namespace: :trusts) do
-        response = Faraday.get(SEARCH_URL, search: content) do |req|
-          req.headers["Authorization"] = "Bearer #{token}"
-        end
+        response = Api.get(SEARCH_URL, search: content)
         raise "API call to /trusts to search for \"#{content}\" failed with: #{response.body}" unless response.success?
 
         response.body
@@ -27,11 +24,8 @@ class Trust
 
     def find(id)
       payload = ModelCache.get(id) || begin
-        token = BearerToken.token
         url = File.join(SEARCH_URL, id)
-        response = Faraday.get(url) do |req|
-          req.headers["Authorization"] = "Bearer #{token}"
-        end
+        response = Api.get(url)
         JSON.parse(response.body)
       end
 

--- a/app/services/api.rb
+++ b/app/services/api.rb
@@ -1,0 +1,32 @@
+class Api
+  def self.get(*args)
+    new(*args).get
+  end
+
+  def self.post(*args)
+    new(*args).post
+  end
+
+  attr_reader :url, :query
+
+  def initialize(url, query = nil)
+    @url = url
+    @query = query
+  end
+
+  def get
+    Faraday.get(url, query) do |req|
+      req.headers["Authorization"] = "Bearer #{bearer_token}"
+    end
+  end
+
+  def post
+    Faraday.post(url, query.to_json, "Content-Type" => "application/json") do |req|
+      req.headers["Authorization"] = "Bearer #{bearer_token}"
+    end
+  end
+
+  def bearer_token
+    BearerToken.token
+  end
+end

--- a/app/views/dashboard/_transfers.html.erb
+++ b/app/views/dashboard/_transfers.html.erb
@@ -4,3 +4,53 @@
     <p><%= link_to t(".new_academy_transfer_button"), trusts_url, class: "govuk-button", data: { turbolinks: false } %>
   </div>
 </div>
+
+<section id="in-progress-projects" class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t(".in_progress_projects_heading") %></th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"><%= t("generic.status") %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @in_progress_projects.each do |in_progress_project| %>
+          <tr class="govuk-table__row">
+            <td>
+              <%= in_progress_project.project_name %>
+            </td>
+            <td class="govuk-tag govuk-tag--blue">
+              <%= t("models.project.#{in_progress_project.status_key}") %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="completed-projects" class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t(".completed_projects_heading") %></th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"><%= t("generic.status") %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @completed_projects.each do |in_progress_project| %>
+          <tr class="govuk-table__row">
+            <td>
+              <%= in_progress_project.project_name %>
+            </td>
+            <td class="govuk-tag govuk-tag--green">
+              <%= t("models.project.#{in_progress_project.status_key}") %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -16,4 +16,3 @@
   <%= render_as_tab :significant_change %>
   <%= render_as_tab :concerns %>
 </div>
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,9 @@ en:
       ofsted_inspection_date: Last inspection
       ofsted_inspection_date_formatted: Last inspection
       pfi: PFI (private finance initiative)
+    project:
+      in_progress: In progress
+      completed: Completed
 
   academies:
     index:
@@ -72,6 +75,8 @@ en:
     transfers:
       new_academy_transfer: Set up a new academy transfer project
       new_academy_transfer_button: Start a new project
+      in_progress_projects_heading: Ongoing academy transfer projects
+      completed_projects_heading: Archieved academy transfer projects
     conversions:
       sub_heading: Conversions
     significant_change:
@@ -129,4 +134,5 @@ en:
     no: No
     back: Back
     change: Change
+    status: Status
       

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -17,6 +17,60 @@ RSpec.describe Project, type: :model do
     )
   end
 
+  describe ".search" do
+    let(:query) { {} }
+    let(:projects) { build_list :project, 10 }
+    subject { described_class.search(query) }
+
+    before do
+      mock_project_search(projects, query)
+    end
+
+    it "returns an array of projects" do
+      expect(subject.length).to eq(projects.length)
+      expect(subject.first.as_json).to eq(projects.first.as_json)
+    end
+
+    context "with a search term" do
+      let(:query) { { search_term: "foo" } }
+
+      it "returns an array of projects" do
+        expect(subject.length).to eq(projects.length)
+        expect(subject.first.as_json).to eq(projects.first.as_json)
+      end
+    end
+  end
+
+  describe ".completed" do
+    let(:query) { { status: 2 } }
+    let(:projects) { build_list :project, 10 }
+    subject { described_class.completed }
+
+    before do
+      mock_project_search(projects, query)
+    end
+
+    it "returns an array of projects" do
+      expect(subject.length).to eq(projects.length)
+      expect(subject.first.as_json).to eq(projects.first.as_json)
+    end
+  end
+
+  describe ".in_progress" do
+    let(:query) { { status: 1 } }
+    let(:projects) { build_list :project, 10 }
+    subject { described_class.in_progress }
+
+    before do
+      mock_project_search(projects, query)
+    end
+
+    it "returns an array of projects" do
+      expect(subject.length).to eq(projects.length)
+      expect(subject.first.as_json).to eq(projects.first.as_json)
+    end
+  end
+
   describe "#save" do
     let(:response) { project.save }
     let(:response_body) { { foo: :bar }.to_json }
@@ -60,6 +114,23 @@ RSpec.describe Project, type: :model do
 
     it "contain outgoing trust id" do
       expect(project_academy.dig(:trusts, 0, :trust_id)).to eq(outgoing_trust.id)
+    end
+  end
+
+  describe "#status_key" do
+    let(:status) { 1 }
+    let(:project) { build :project, project_status: status }
+
+    it "returns the matching key from STATUS" do
+      expect(project.status_key).to eq(:in_progress)
+    end
+
+    context "when complete" do
+      let(:status) { 2 }
+
+      it "returns the matching key from STATUS" do
+        expect(project.status_key).to eq(:completed)
+      end
     end
   end
 end

--- a/spec/requests/dashboard_request_spec.rb
+++ b/spec/requests/dashboard_request_spec.rb
@@ -1,14 +1,31 @@
 require "rails_helper"
 
 RSpec.describe "Dashboards", type: :request do
+  let(:in_progress_projects) { build_list :project, 6, project_status: 1 }
+  let(:completed_projects) { build_list :project, 6, project_status: 2 }
   let(:user) { create :user }
 
   before { sign_in user }
 
   describe "GET /" do
+    before do
+      mock_project_search(in_progress_projects, status: 1, ascending: false, page_size: 5)
+      mock_project_search(completed_projects, status: 2, ascending: false, page_size: 5)
+    end
+
     it "returns http success" do
       get root_path
       expect(response).to have_http_status(:success)
+    end
+
+    it "displays in progress projects" do
+      get root_path
+      expect(response.body).to include(in_progress_projects.first.project_name)
+    end
+
+    it "displays in completed projects" do
+      get root_path
+      expect(response.body).to include(completed_projects.first.project_name)
     end
   end
 end

--- a/spec/services/api_spec.rb
+++ b/spec/services/api_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe Api do
+  let(:root_url) { Faker::Internet.url(host: "example.com") }
+  let(:query) { nil }
+  let(:url) do
+    uri = URI(root_url)
+    uri.query = query.to_query if query
+    uri.to_s
+  end
+
+  let(:body) { { foo: :bar }.to_json }
+  let(:access_token) { SecureRandom.uuid }
+  let(:stub_get) do
+    stub_request(:get, url)
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(body: body)
+  end
+  let(:stub_post) do
+    stub_request(:post, root_url)
+      .with(
+        headers: { "Authorization" => "Bearer #{access_token}" },
+        body: query.to_json,
+      )
+      .to_return(body: body)
+  end
+  let(:stub_call_to_api) { stub_get }
+
+  let(:api) { described_class.new(root_url, query) }
+
+  before do
+    mock_bearer_token_retrieval(access_token)
+    stub_call_to_api
+  end
+
+  describe ".get" do
+    subject { described_class.get(root_url, query) }
+
+    it "returns body" do
+      expect(subject.body).to eq(body)
+    end
+
+    context "with query" do
+      let(:query) { { find: :me } }
+
+      it "returns body" do
+        expect(subject.body).to eq(body)
+      end
+    end
+  end
+
+  describe "#get" do
+    subject { api.get }
+
+    it "returns body" do
+      expect(subject.body).to eq(body)
+    end
+
+    context "with query" do
+      let(:query) { { find: :me } }
+
+      it "returns body" do
+        expect(subject.body).to eq(body)
+      end
+    end
+  end
+
+  describe ".post" do
+    let(:method) { :post }
+    let(:query) { { some: :data } }
+    let(:stub_call_to_api) { stub_post }
+
+    subject { described_class.post(root_url, query) }
+
+    it "returns body" do
+      expect(subject.body).to eq(body)
+    end
+  end
+
+  describe "#post" do
+    let(:method) { :post }
+    let(:query) { { some: :data } }
+    let(:stub_call_to_api) { stub_post }
+
+    subject { api.post }
+
+    it "returns body" do
+      expect(subject.body).to eq(body)
+    end
+  end
+end

--- a/spec/support/webmock_stubs.rb
+++ b/spec/support/webmock_stubs.rb
@@ -5,14 +5,12 @@ end
 def mock_trust_search(search_string, trusts_to_return)
   uri = URI(Trust::SEARCH_URL)
   uri.query = "search=#{search_string}"
-
-  access_token = SecureRandom.uuid
-  mock_bearer_token_retrieval(access_token)
+  mock_bearer_token_retrieval(mock_api_access_token)
 
   body = trusts_to_return.map { |trust| camelcase_attributes(trust) }
 
   stub_request(:get, uri.to_s)
-    .with(headers: { "Authorization" => "Bearer #{access_token}" })
+    .with(headers: { "Authorization" => "Bearer #{mock_api_access_token}" })
     .to_return(body: body.to_json)
 end
 
@@ -37,7 +35,7 @@ def mock_academies_belonging_to_trust(trust, academies)
 end
 
 def mock_project_save(project, response_body = {})
-  url = Project::SAVE_URL
+  url = Project::PROJECTS_URL
   mock_bearer_token_retrieval(mock_api_access_token)
 
   stub_request(:post, url)
@@ -45,6 +43,20 @@ def mock_project_save(project, response_body = {})
       body: project.api_payload.to_json,
       headers: { "Authorization" => "Bearer #{mock_api_access_token}" },
     ).to_return(body: response_body)
+end
+
+def mock_project_search(projects_to_return, args = {})
+  mock_bearer_token_retrieval(mock_api_access_token)
+  args.transform_keys! { |key| key.to_s.camelize(:lower) }
+  uri = URI(Project::PROJECTS_URL)
+  uri.query = args.to_query
+
+  projects = projects_to_return.map { |project| camelcase_attributes(project) }
+  body = { projects: projects }
+
+  stub_request(:get, uri.to_s)
+    .with(headers: { "Authorization" => "Bearer #{mock_api_access_token}" })
+    .to_return(body: body.to_json)
 end
 
 def mock_api_access_token


### PR DESCRIPTION
### Context
The dashboard should show a list of the 5 most recent in progress projects, and the 5 most recently completed project

### Changes proposed in this pull request

- Add `Api` class to wrap calls to API and simplify code
- Add `search`, `completed` and `in_progress` class methods to `Project` to allow arrays of projects to be gathered from the API
- Add `status_key` instance method to projects to provide convenient key for status
- Present lists of projects in two tables on the dashboard view.

### Guidance to review

The dashboard with this change looks like this:

![dashboard_project_lists](https://user-images.githubusercontent.com/213040/106156281-3ef34700-6179-11eb-932c-ab8d9163731c.png)
