### PR TITLE
Rename trusts controller as outgoing trusts controller

### DIFF
--- a/app/controllers/academies_controller.rb
+++ b/app/controllers/academies_controller.rb
@@ -11,7 +11,7 @@ class AcademiesController < ApplicationController
   def create
     if academy_data.present?
       session_store.set :academy_ids, academy_data
-      redirect_to trust_identify_path(params[:trust_id])
+      redirect_to outgoing_trust_identify_path(outgoing_trust_id)
     else
       @error = I18n.t("errors.trust.no_academy_selected")
       academies
@@ -23,11 +23,11 @@ class AcademiesController < ApplicationController
 private
 
   def session_store
-    @session_store ||= SessionStore.new(current_user, params[:trust_id])
+    @session_store ||= SessionStore.new(current_user, outgoing_trust_id)
   end
 
   def academies
-    @academies ||= Academy.belonging_to_trust(params[:trust_id])
+    @academies ||= Academy.belonging_to_trust(outgoing_trust_id)
   end
 
   def academy_data
@@ -36,5 +36,9 @@ private
 
   def academy_ids
     @academy_ids ||= session_store.get(:academy_ids) || []
+  end
+
+  def outgoing_trust_id
+    params[:outgoing_trust_id]
   end
 end

--- a/app/controllers/identify_controller.rb
+++ b/app/controllers/identify_controller.rb
@@ -6,7 +6,7 @@ class IdentifyController < ApplicationController
   def create
     if trust_identified
       session_store.set :incoming_trust_identified, trust_identified
-      redirect_to trust_incoming_trusts_path(outgoing_trust_id)
+      redirect_to outgoing_trust_incoming_trusts_path(outgoing_trust_id)
     else
       @error = I18n.t("errors.must_select_yes_or_no")
       render :show
@@ -16,7 +16,7 @@ class IdentifyController < ApplicationController
 private
 
   def session_store
-    @session_store ||= SessionStore.new(current_user, params[:trust_id])
+    @session_store ||= SessionStore.new(current_user, outgoing_trust_id)
   end
 
   def trust_identified
@@ -24,6 +24,6 @@ private
   end
 
   def outgoing_trust_id
-    @outgoing_trust_id = params[:trust_id]
+    @outgoing_trust_id ||= params[:outgoing_trust_id]
   end
 end

--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -19,7 +19,7 @@ class IncomingTrustsController < ApplicationController
       incoming_trusts
       render :index
     else
-      redirect_to new_trust_project_path(outgoing_trust_id)
+      redirect_to new_outgoing_trust_project_path(outgoing_trust_id)
     end
   end
 
@@ -27,17 +27,17 @@ class IncomingTrustsController < ApplicationController
     if incoming_trust_ids.delete(params[:id])
       session_store.set :incoming_trust_ids, incoming_trust_ids
     end
-    redirect_to(trust_incoming_trusts_path(outgoing_trust_id))
+    redirect_to(outgoing_trust_incoming_trusts_path(outgoing_trust_id))
   end
 
 private
 
   def session_store
-    @session_store ||= SessionStore.new(current_user, params[:trust_id])
+    @session_store ||= SessionStore.new(current_user, params[:outgoing_trust_id])
   end
 
   def outgoing_trust_id
-    @outgoing_trust_id = params[:trust_id]
+    @outgoing_trust_id = params[:outgoing_trust_id]
   end
 
   def trust_identified

--- a/app/controllers/outgoing_trusts_controller.rb
+++ b/app/controllers/outgoing_trusts_controller.rb
@@ -1,0 +1,21 @@
+class OutgoingTrustsController < ApplicationController
+  before_action :authenticate_user!
+
+  breadcrumb :dashboard, :root_path
+  breadcrumb :add_new_project, :trusts_path
+
+  # GET /trusts/new
+  def new; end
+
+  # POST /trusts
+  def create
+    @trusts = Trust.search(params["input-autocomplete"])
+    redirect_to outgoing_trust_path(@trusts.first.id) if @trusts.one?
+  end
+
+  # GET /trusts/1
+  def show
+    @trust = Trust.find(params[:id])
+    breadcrumb :trust_details, outgoing_trust_path(@trust.id)
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,17 +27,17 @@ private
       project_initiator_full_name: current_user.username,
       project_status: Project::STATUS[:in_progress],
       academy_ids: session_store.get(:academy_ids),
-      outgoing_trust_id: params[:trust_id],
+      outgoing_trust_id: outgoing_trust_id,
       incoming_trust_id: session_store.get(:incoming_trust_ids).first,
     }
   end
 
   def session_store
-    @session_store ||= SessionStore.new(current_user, params[:trust_id])
+    @session_store ||= SessionStore.new(current_user, outgoing_trust_id)
   end
 
   def outgoing_trust_id
-    @outgoing_trust_id = params[:trust_id]
+    @outgoing_trust_id = params[:outgoing_trust_id]
   end
 
   def selected_academy_ids

--- a/app/controllers/trusts_controller.rb
+++ b/app/controllers/trusts_controller.rb
@@ -1,27 +1,8 @@
 class TrustsController < ApplicationController
   before_action :authenticate_user!
 
-  breadcrumb :dashboard, :root_path
-  breadcrumb :add_new_project, :trusts_path
-
-  # GET /trusts
-  def index; end
-
-  # GET /trusts/search
-  def search
+  def index
     @trusts = Trust.search(params["input-autocomplete"])
-
-    respond_to do |format|
-      format.html do
-        redirect_to trust_path(@trusts.first.id) if @trusts.one?
-      end
-      format.json { render json: @trusts.map(&:trust_name) }
-    end
-  end
-
-  # GET /trusts/1
-  def show
-    @trust = Trust.find(params[:id])
-    breadcrumb :trust_details, trust_path(@trust.id)
+    render json: @trusts.map(&:trust_name)
   end
 end

--- a/app/views/academies/index.html.erb
+++ b/app/views/academies/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render("error_summary", errors: [@error]) if @error %>
 
-<%= form_with(url: trust_academies_path(params[:trust_id]), local: true) do |form| %>
+<%= form_with(url: outgoing_trust_academies_path(params[:outgoing_trust_id]), local: true) do |form| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="academy-hint">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/dashboard/_transfers.html.erb
+++ b/app/views/dashboard/_transfers.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body"><%= t(".new_academy_transfer") %></p>
-    <p><%= link_to t(".new_academy_transfer_button"), trusts_url, class: "govuk-button", data: { turbolinks: false } %>
+    <p><%= link_to t(".new_academy_transfer_button"), new_outgoing_trust_path, class: "govuk-button", data: { turbolinks: false } %>
   </div>
 </div>
 

--- a/app/views/identify/show.html.erb
+++ b/app/views/identify/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render("error_summary", errors: [@error]) if @error %>
 
-<%= form_with(url: trust_identify_path(params[:trust_id]), local: true) do |form| %>
+<%= form_with(url: outgoing_trust_identify_path(params[:outgoing_trust_id]), local: true) do |form| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/incoming_trusts/index.html.erb
+++ b/app/views/incoming_trusts/index.html.erb
@@ -12,7 +12,7 @@
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header"><%= incoming_trust.label %></th>
         <td class="govuk-table__cell">
-          <%= link_to t(".remove_trust"), trust_incoming_trust_path(params[:trust_id], incoming_trust.id), method: :delete %>
+          <%= link_to t(".remove_trust"), outgoing_trust_incoming_trust_path(params[:outgoing_trust_id], incoming_trust.id), method: :delete %>
         </td>
       </tr>
     <% end %>
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: search_trust_incoming_trusts_path, method: :get, local: true do |form| %>
+    <%= form_with url: search_outgoing_trust_incoming_trusts_path, method: :get, local: true do |form| %>
 
       <div class="govuk-form-group">
         <%= form.label :autocomplete_trusts, t(".search_label"), class: "govuk-hint" %>

--- a/app/views/incoming_trusts/search.html.erb
+++ b/app/views/incoming_trusts/search.html.erb
@@ -12,8 +12,8 @@
         <%=
             link_to(
                 trust.trust_name,
-                search_trust_incoming_trusts_path(
-                  params[:trust_id],
+                search_outgoing_trust_incoming_trusts_path(
+                  params[:outgoing_trust_id],
                   "input-autocomplete" => trust.trust_name,
                   commit: t("incoming_trusts.index.add_trust")
                 )

--- a/app/views/outgoing_trusts/create.html.erb
+++ b/app/views/outgoing_trusts/create.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <ul>
     <% @trusts.each do |trust| %>
-      <li><%= link_to trust.trust_name, trust_path(trust.id) %></li>
+      <li><%= link_to trust.trust_name, outgoing_trust_path(trust.id) %></li>
     <% end %>
   </div>
 </div>

--- a/app/views/outgoing_trusts/new.html.erb
+++ b/app/views/outgoing_trusts/new.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: search_trusts_path, method: :get, local: true do |form| %>
+    <%= form_with url: outgoing_trusts_path, local: true do |form| %>
     
       <div class="govuk-form-group">
         <%= form.label :autocomplete_trusts, t(".search_label"), class: "govuk-hint" %>

--- a/app/views/outgoing_trusts/show.html.erb
+++ b/app/views/outgoing_trusts/show.html.erb
@@ -27,5 +27,5 @@
   </div>
 </dl>
 
-<%= link_to t(".next_action_link"), trust_academies_path(@trust.id), class: "govuk-button" %>
+<%= link_to t(".next_action_link"), outgoing_trust_academies_path(@trust.id), class: "govuk-button" %>
 

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-width-container">
   <h2 class="govuk-heading-m"><%= t(".outgoing_trust") %></h2>
   <dl class="govuk-summary-list">
-    <%= summary_row(@outgoing_trust, :trust_name, change_url: trusts_path) %>
+    <%= summary_row(@outgoing_trust, :trust_name, change_url: new_outgoing_trust_path) %>
     <%= summary_row(@outgoing_trust, :trust_reference_number) %>
   </dl>
 </div>
@@ -17,7 +17,7 @@
 
   <% @academies.each do |academy| %>
     <dl class="govuk-summary-list">
-      <%= summary_row(academy, :academy_name, change_url: trust_academies_path(@outgoing_trust.id)) %>
+      <%= summary_row(academy, :academy_name, change_url: outgoing_trust_academies_path(@outgoing_trust.id)) %>
       <% [
          :urn,
          :local_authority_name,
@@ -38,7 +38,7 @@
 
   <% @incoming_trusts.each do |incoming_trust| %>
     <dl class="govuk-summary-list">
-      <%= summary_row(incoming_trust, :trust_name, change_url: trust_incoming_trusts_path(@outgoing_trust.id)) %>
+      <%= summary_row(incoming_trust, :trust_name, change_url: outgoing_trust_incoming_trusts_path(@outgoing_trust.id)) %>
       <% [
            :companies_house_number,
            :trust_reference_number,
@@ -61,5 +61,5 @@
 </div>
 
 <div class="govuk-width-container">
-  <%= link_to t(".next_action_link"), trust_projects_path(@outgoing_trust_id), method: :post, class: "govuk-button" %>
+  <%= link_to t(".next_action_link"), outgoing_trust_projects_path(@outgoing_trust_id), method: :post, class: "govuk-button" %>
 </div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -11,5 +11,5 @@ Turbolinks.start();
 initAll();
 
 document.addEventListener('turbolinks:load', () => {
-  autocompleteSelection('#autocomplete_trusts', '/trusts/search.json');
+  autocompleteSelection('#autocomplete_trusts', '/trusts.json');
 });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,20 @@ en:
     search:
       page_header: Transfer an academy to another trust
       heading: Select incoming trust
+  outgoing_trusts:
+    new:
+      page_header: Transfer an academy to another trust
+      heading: Add the outgoing trust name
+      search_label: Search by name, trust reference number or companies house number
+      search_button: Search
+    index:
+      page_header: Transfer an academy to another trust
+      heading: Select Trust
+    show:
+      page_header: Transfer an academy to another trust
+      heading: Outgoing trust details
+      <<: *trust_attributes
+      next_action_link: Select Trust
   projects:
     new:
       page_header: Transfer an academy to another trust
@@ -109,20 +123,6 @@ en:
       next_action_link: Save and continue
       <<: *trust_attributes
       <<: *academy_attributes
-  trusts:
-    index:
-      page_header: Transfer an academy to another trust
-      heading: Add the outgoing trust name
-      search_label: Search by name, trust reference number or companies house number
-      search_button: Search
-    search:
-      page_header: Transfer an academy to another trust
-      heading: Select Trust
-    show:
-      page_header: Transfer an academy to another trust
-      heading: Outgoing trust details
-      <<: *trust_attributes
-      next_action_link: Select Trust
 
   errors:
     summary: There is a problem

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :trusts, only: %i[index show] do
-    get :search, on: :collection
+  resources :outgoing_trusts, only: %i[new create show], path: :outgoing do
     resources :academies, only: %i[index create]
     resource :identify, only: %i[show create], controller: :identify
     resources :incoming_trusts, only: %i[index create destroy], path: :incoming do
@@ -12,6 +11,8 @@ Rails.application.routes.draw do
     end
     resources :projects, only: %i[new create]
   end
+
+  resources :trusts, only: [:index]
 
   get "/pages/:page", to: "pages#show"
 

--- a/spec/requests/academies_spec.rb
+++ b/spec/requests/academies_spec.rb
@@ -10,18 +10,18 @@ RSpec.describe "Academies", type: :request do
 
   before { sign_in user }
 
-  describe "GET /trust/:trust_id/academies" do
+  describe "GET /outgoing_trust/:outgoing_trust_id/academies" do
     before do
       mock_academies_belonging_to_trust(trust, academies)
     end
 
     it "renders a successful response" do
-      get trust_academies_path(trust.id)
+      get outgoing_trust_academies_path(trust.id)
       expect(response).to be_successful
     end
   end
 
-  describe "POST /trust/:trust_id/academies" do
+  describe "POST /outgoing_trust/:outgoing_trust_id/academies" do
     let(:params) do
       {
         trust: {
@@ -31,7 +31,7 @@ RSpec.describe "Academies", type: :request do
     end
 
     subject do
-      post trust_academies_path(trust.id), params: params
+      post outgoing_trust_academies_path(trust.id), params: params
     end
 
     it "stores the academy ids in session store" do
@@ -40,7 +40,7 @@ RSpec.describe "Academies", type: :request do
 
     it "redirects to next page" do
       subject
-      expect(response).to redirect_to(trust_identify_path(trust.id))
+      expect(response).to redirect_to(outgoing_trust_identify_path(trust.id))
     end
 
     context "with noting selected" do

--- a/spec/requests/identify_request_spec.rb
+++ b/spec/requests/identify_request_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe "Identify", type: :request do
 
   before { sign_in user }
 
-  describe "GET /trust/:trust_id/identify" do
+  describe "GET /outgoing_trust/:outgoing_trust_id/identify" do
     it "returns http success" do
-      get trust_identify_path(trust.id)
+      get outgoing_trust_identify_path(trust.id)
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "POST /trust/:trust_id/identify" do
+  describe "POST /outgoing_trust/:outgoing_trust_id/identify" do
     let(:trust_identified) { "yes" }
     let(:params) do
       { trust_identified: trust_identified }
     end
-    subject { post trust_identify_path(trust.id), params: params }
+    subject { post outgoing_trust_identify_path(trust.id), params: params }
 
     it "redirects to incoming trusts" do
       subject
-      expect(response).to redirect_to(trust_incoming_trusts_path(trust.id))
+      expect(response).to redirect_to(outgoing_trust_incoming_trusts_path(trust.id))
     end
 
     it "records choice in session_store" do
@@ -36,7 +36,7 @@ RSpec.describe "Identify", type: :request do
 
       it "redirects to identified" do
         subject
-        expect(response).to redirect_to(trust_incoming_trusts_path(trust.id))
+        expect(response).to redirect_to(outgoing_trust_incoming_trusts_path(trust.id))
       end
 
       it "records choice in session_store" do

--- a/spec/requests/incoming_trusts_spec.rb
+++ b/spec/requests/incoming_trusts_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "IncomingTrusts", type: :request do
 
   before { sign_in user }
 
-  describe "GET /trust/:trust_id/incoming" do
-    subject { get trust_incoming_trusts_path(trust.id) }
+  describe "GET /outgoing_trust/:outgoing_trust_id/incoming" do
+    subject { get outgoing_trust_incoming_trusts_path(trust.id) }
 
     it "returns http success" do
       subject
@@ -30,7 +30,7 @@ RSpec.describe "IncomingTrusts", type: :request do
     end
   end
 
-  describe "GET /trusts/:trust_id/incoming/search" do
+  describe "GET /outgoing_trusts/:outgoing_trust_id/incoming/search" do
     let(:query) { incoming_trust.trust_name }
     let(:trusts) { [incoming_trust] }
     let(:redis) { Redis.new }
@@ -48,11 +48,11 @@ RSpec.describe "IncomingTrusts", type: :request do
       redis.del(redis_key)
       mock_trust_search(query, trusts)
       session_store.set :incoming_trust_ids, previously_saved
-      get search_trust_incoming_trusts_url(outgoing_trust.id), params: params
+      get search_outgoing_trust_incoming_trusts_url(outgoing_trust.id), params: params
     end
 
     it "Redirects to new projects for single result" do
-      expect(response).to redirect_to(new_trust_project_path(outgoing_trust.id))
+      expect(response).to redirect_to(new_outgoing_trust_project_path(outgoing_trust.id))
     end
 
     context "when multiple results" do
@@ -60,7 +60,7 @@ RSpec.describe "IncomingTrusts", type: :request do
       let(:trusts) { build_list :trust, 2, trust_name: query }
       let(:incoming_trust) { trusts.first }
       let(:link_back_to_search) do
-        search_trust_incoming_trusts_path(
+        search_outgoing_trust_incoming_trusts_path(
           outgoing_trust.id,
           "input-autocomplete" => incoming_trust.trust_name,
           commit: I18n.t("incoming_trusts.index.add_trust"),
@@ -119,17 +119,17 @@ RSpec.describe "IncomingTrusts", type: :request do
       let(:previously_saved) { [incoming_trust.id] }
 
       it "Redirects to new project for single result" do
-        expect(response).to redirect_to(new_trust_project_path(outgoing_trust.id))
+        expect(response).to redirect_to(new_outgoing_trust_project_path(outgoing_trust.id))
       end
     end
   end
 
-  describe "DELETE /trusts/:trust_id/incoming/:id" do
-    subject { delete trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id) }
+  describe "DELETE /outgoing_trusts/:outgoing_trust_id/incoming/:id" do
+    subject { delete outgoing_trust_incoming_trust_path(outgoing_trust.id, incoming_trust.id) }
 
     it "Redirects to the search page" do
       subject
-      expect(response).to redirect_to(trust_incoming_trusts_path(outgoing_trust.id))
+      expect(response).to redirect_to(outgoing_trust_incoming_trusts_path(outgoing_trust.id))
     end
 
     context "incoming trust is present in session store" do
@@ -144,7 +144,7 @@ RSpec.describe "IncomingTrusts", type: :request do
 
       it "Redirects to the search page" do
         subject
-        expect(response).to redirect_to(trust_incoming_trusts_path(outgoing_trust.id))
+        expect(response).to redirect_to(outgoing_trust_incoming_trusts_path(outgoing_trust.id))
       end
     end
   end

--- a/spec/requests/outgoing_trusts_spec.rb
+++ b/spec/requests/outgoing_trusts_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "/trusts", type: :request do
+RSpec.describe "/outgoing_trusts", type: :request do
   let(:trust) { build :trust }
   let(:query) { trust.trust_name }
   let(:trusts) { [trust] }
@@ -13,21 +13,21 @@ RSpec.describe "/trusts", type: :request do
     sign_in user
   end
 
-  describe "GET /index" do
+  describe "GET /new" do
     it "renders a successful response" do
-      get trusts_url
+      get new_outgoing_trust_url
       expect(response).to be_successful
     end
   end
 
-  describe "GET /search" do
+  describe "POST /" do
     before do
       mock_trust_search(query, trusts)
-      get search_trusts_url, params: { "input-autocomplete" => query }
+      post outgoing_trusts_url, params: { "input-autocomplete" => query }
     end
 
     it "Redirects to show for single result" do
-      expect(response).to redirect_to(trust_path(trust.id))
+      expect(response).to redirect_to(outgoing_trust_path(trust.id))
     end
 
     context "when multiple results" do
@@ -41,24 +41,8 @@ RSpec.describe "/trusts", type: :request do
 
       it "displays link to trust's show page" do
         expect(response.body).to include(trust.trust_name)
-        expect(response.body).to include(trust_path(trust.id))
+        expect(response.body).to include(outgoing_trust_path(trust.id))
       end
-    end
-  end
-
-  describe "GET /search.json" do
-    let(:query) { Faker::Educator.secondary_school }
-    let(:trust) { build :trust, trust_name: "#{query} one" }
-    let(:trust_two) { build :trust, trust_name: "#{query} two" }
-    let(:trusts) { [trust, trust_two] }
-
-    before do
-      mock_trust_search(query, trusts)
-      get search_trusts_url, params: { "input-autocomplete" => query }, as: :json
-    end
-
-    it "returns the trust names" do
-      expect(response.body).to eq([trust.trust_name, trust_two.trust_name].to_json)
     end
   end
 
@@ -68,7 +52,7 @@ RSpec.describe "/trusts", type: :request do
     end
 
     it "renders a successful response" do
-      get trust_url(trust.id)
+      get outgoing_trust_url(trust.id)
       expect(response).to be_successful
     end
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "/projects", type: :request do
       session_store.set(:incoming_trust_ids, [incoming_trust.id])
       mock_project_save(project, response_body)
     end
-    subject { post trust_projects_path(outgoing_trust.id) }
+    subject { post outgoing_trust_projects_path(outgoing_trust.id) }
 
     it "renders successfully" do
       subject
@@ -45,7 +45,7 @@ RSpec.describe "/projects", type: :request do
       mock_trust_find(outgoing_trust)
       session_store.set :academy_ids, [academy.id]
       session_store.set :incoming_trust_ids, [incoming_trust.id]
-      get new_trust_project_path(outgoing_trust.id, incoming_trust.id)
+      get new_outgoing_trust_project_path(outgoing_trust.id, incoming_trust.id)
     end
 
     it "renders a successful response" do

--- a/spec/requests/trust_request_spec.rb
+++ b/spec/requests/trust_request_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "/trusts", type: :request do
+  describe "GET /" do
+    let(:query) { Faker::Educator.secondary_school }
+    let(:trust) { build :trust, trust_name: "#{query} one" }
+    let(:trust_two) { build :trust, trust_name: "#{query} two" }
+    let(:trusts) { [trust, trust_two] }
+    let(:user) { create :user }
+    let(:redis) { Redis.new }
+    let(:redis_key) { "test_block_cache_trusts_#{query}" }
+
+    before do
+      redis.del(redis_key)
+      sign_in user
+      mock_trust_search(query, trusts)
+      get trusts_url, params: { "input-autocomplete" => query }, as: :json
+    end
+
+    it "returns the trust names" do
+      expect(response.body).to eq([trust.trust_name, trust_two.trust_name].to_json)
+    end
+  end
+end


### PR DESCRIPTION
### Context
To clarify the role of the first trust controller to that of identifying the outgoing trust
Also restructuring controller to have more standard rails action names

### Changes proposed in this pull request
- Paths to controllers within the scope of the outgoing trust controller also need updating
- Move JSON response for trusts search to separate new trusts controller

