### PR TITLE
Add project search to dashboard

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,6 +19,14 @@ class ProjectsController < ApplicationController
     }
   end
 
+  # GET /projects
+  def index
+    @projects = Project.search(params)
+  end
+
+  # GET/projects/:id
+  def show; end
+
 private
 
   def project_params

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,6 +21,8 @@ class Project
     3 => "Ofsted Inadequate Rating",
   }.freeze
 
+  API_SEARCH_ARGS = %w[searchTerm status ascending pageSize pageNumber].freeze
+
   attr_accessor :project_id, :project_name, :project_initiator_full_name, :project_initiator_uid, :project_status,
                 :esfa_intervention_reasons, :esfa_intervention_reasons_explained, :rdd_or_rsc_intervention_reasons,
                 :rdd_or_rsc_intervention_reasons_explained, :academy_ids, :outgoing_trust_id, :incoming_trust_id
@@ -36,6 +38,7 @@ class Project
 
     def search(args = {})
       query = args.transform_keys { |key| key.to_s.camelize(:lower) }
+      query.slice!(*API_SEARCH_ARGS)
       response = Api.get(PROJECTS_URL, query)
       data = JSON.parse(response.body)
       data["projects"].map { |project_data| new(project_data) }

--- a/app/views/dashboard/_transfers.html.erb
+++ b/app/views/dashboard/_transfers.html.erb
@@ -2,6 +2,14 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body"><%= t(".new_academy_transfer") %></p>
     <p><%= link_to t(".new_academy_transfer_button"), new_outgoing_trust_path, class: "govuk-button", data: { turbolinks: false } %>
+
+    <%= form_tag(projects_path, method: :get) do %>
+      <div class="govuk-form-group">
+        <%= label_tag :search_term, t(".search_label"), class: "govuk-body" %>
+        <%= text_field_tag :search_term, nil, class: "govuk-input" %>
+      </div>
+      <%= submit_tag t(".search_button"), class: "govuk-button govuk-button--secondary" %>
+    <% end %>
   </div>
 </div>
 
@@ -18,7 +26,7 @@
         <% @in_progress_projects.each do |in_progress_project| %>
           <tr class="govuk-table__row">
             <td>
-              <%= in_progress_project.project_name %>
+              <%= link_to in_progress_project.project_name, project_path(in_progress_project.project_id) %>
             </td>
             <td class="govuk-tag govuk-tag--blue">
               <%= t("models.project.#{in_progress_project.status_key}") %>
@@ -43,7 +51,7 @@
         <% @completed_projects.each do |in_progress_project| %>
           <tr class="govuk-table__row">
             <td>
-              <%= in_progress_project.project_name %>
+              <%= link_to in_progress_project.project_name, project_path(in_progress_project.project_id) %>
             </td>
             <td class="govuk-tag govuk-tag--green">
               <%= t("models.project.#{in_progress_project.status_key}") %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:page_header) { t(".page_header") } %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header"><%= t(".name") %></th>
+      <th scope="col" class="govuk-table__header"><%= t(".link") %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= project.project_name %></th>
+        <td class="govuk-table__cell"><%= link_to t(".show"), project_path(project.project_id) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-width-container">
+  To be built
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,8 @@ en:
       new_academy_transfer_button: Start a new project
       in_progress_projects_heading: Ongoing academy transfer projects
       completed_projects_heading: Archieved academy transfer projects
+      search_label: Search for projects by name or reference number
+      search_button: Search
     conversions:
       sub_heading: Conversions
     significant_change:
@@ -123,6 +125,11 @@ en:
       next_action_link: Save and continue
       <<: *trust_attributes
       <<: *academy_attributes
+    index:
+      page_header: Projects
+      name: Name
+      link: Link
+      show: Show
 
   errors:
     summary: There is a problem

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   end
 
   resources :trusts, only: [:index]
+  resources :projects, only: %i[index show]
 
   get "/pages/:page", to: "pages#show"
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -64,4 +64,73 @@ RSpec.describe "/projects", type: :request do
       expect(response.body).to include(academy.urn)
     end
   end
+
+  describe "GET /projects" do
+    let(:projects) { build_list :project, 2 }
+    let(:args) { {} }
+
+    before do
+      mock_project_search(projects, args)
+      get projects_path, params: args
+    end
+
+    it "displays the projects" do
+      expect(response.body).to include(projects.first.project_name)
+      expect(response.body).to include(projects.last.project_name)
+    end
+
+    context "with search term" do
+      let(:args) { { search_term: Faker::Lorem.word } }
+
+      it "displays the projects" do
+        expect(response.body).to include(projects.first.project_name)
+        expect(response.body).to include(projects.last.project_name)
+      end
+    end
+
+    context "with status" do
+      let(:args) { { status: [1, 2].sample } }
+
+      it "displays the projects" do
+        expect(response.body).to include(projects.first.project_name)
+        expect(response.body).to include(projects.last.project_name)
+      end
+    end
+
+    context "with ascending" do
+      let(:args) { { ascending: [true, false].sample } }
+
+      it "displays the projects" do
+        expect(response.body).to include(projects.first.project_name)
+        expect(response.body).to include(projects.last.project_name)
+      end
+    end
+
+    context "with page size" do
+      let(:args) { { page_size: 20 } }
+
+      it "displays the projects" do
+        expect(response.body).to include(projects.first.project_name)
+        expect(response.body).to include(projects.last.project_name)
+      end
+    end
+
+    context "with page number" do
+      let(:args) { { page_number: 2 } }
+
+      it "displays the projects" do
+        expect(response.body).to include(projects.first.project_name)
+        expect(response.body).to include(projects.last.project_name)
+      end
+    end
+  end
+
+  describe "GET /projects/:id" do
+    let(:project) { build :project }
+
+    it "renders successfully" do
+      get project_path(project.project_id)
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
### Context
When an academy project exist in the system, I want to search for the project and view the project information.

### Changes proposed in this pull request
- Add index and show actions to projects controller
- Update Project.search to remove params keys not needed for API call
- Add search form to dashboard view
- Update project lists on dashboard with links to project pages
- Add routes to projects#index and #show at root

Note: that the index and show views are very basic, but can be easily updated as the designs become available.

### Guidance to review
With these changes in place: 

#### The dashboard
![dashboard_with_search](https://user-images.githubusercontent.com/213040/106603401-265aa680-6556-11eb-9f6f-a58b01388324.png)

#### Project index showing list of matching projects
![project_index](https://user-images.githubusercontent.com/213040/106603458-370b1c80-6556-11eb-9e76-3b07dda7d642.png)

#### Project show showing "To be built"
![project_show](https://user-images.githubusercontent.com/213040/106603504-4722fc00-6556-11eb-8361-0819dfe38dfc.png)

