### PR TITLE
Rename search action as create

### DIFF
--- a/app/controllers/incoming_trusts_controller.rb
+++ b/app/controllers/incoming_trusts_controller.rb
@@ -5,10 +5,10 @@ class IncomingTrustsController < ApplicationController
     incoming_trusts
   end
 
-  def search
+  def create
     @trusts = search_result
 
-    return render :search unless @trusts.one? || empty_search?
+    return render :create unless @trusts.one? || empty_search?
 
     if @trusts.present?
       incoming_trust_ids << @trusts.first.id unless incoming_trust_ids.include?(@trusts.first.id)

--- a/app/views/incoming_trusts/create.html.erb
+++ b/app/views/incoming_trusts/create.html.erb
@@ -12,11 +12,12 @@
         <%=
             link_to(
                 trust.trust_name,
-                search_outgoing_trust_incoming_trusts_path(
+                outgoing_trust_incoming_trusts_path(
                   params[:outgoing_trust_id],
                   "input-autocomplete" => trust.trust_name,
                   commit: t("incoming_trusts.index.add_trust")
-                )
+                ),
+                method: :post
              )
         %>
       </li>

--- a/app/views/incoming_trusts/index.html.erb
+++ b/app/views/incoming_trusts/index.html.erb
@@ -21,7 +21,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: search_outgoing_trust_incoming_trusts_path, method: :get, local: true do |form| %>
+    <%= form_with url: outgoing_trust_incoming_trusts_path, local: true do |form| %>
 
       <div class="govuk-form-group">
         <%= form.label :autocomplete_trusts, t(".search_label"), class: "govuk-hint" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
       search_button: Save and continue
       add_trust: Save and Add
       remove_trust: Remove
-    search:
+    create:
       page_header: Transfer an academy to another trust
       heading: Select incoming trust
   outgoing_trusts:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,7 @@ Rails.application.routes.draw do
   resources :outgoing_trusts, only: %i[new create show], path: :outgoing do
     resources :academies, only: %i[index create]
     resource :identify, only: %i[show create], controller: :identify
-    resources :incoming_trusts, only: %i[index create destroy], path: :incoming do
-      get :search, on: :collection
-    end
+    resources :incoming_trusts, only: %i[index create destroy], path: :incoming
     resources :projects, only: %i[new create]
   end
 

--- a/spec/requests/incoming_trusts_spec.rb
+++ b/spec/requests/incoming_trusts_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "IncomingTrusts", type: :request do
     end
   end
 
-  describe "GET /outgoing_trusts/:outgoing_trust_id/incoming/search" do
+  describe "POST /outgoing_trusts/:outgoing_trust_id/incoming" do
     let(:query) { incoming_trust.trust_name }
     let(:trusts) { [incoming_trust] }
     let(:redis) { Redis.new }
@@ -48,7 +48,7 @@ RSpec.describe "IncomingTrusts", type: :request do
       redis.del(redis_key)
       mock_trust_search(query, trusts)
       session_store.set :incoming_trust_ids, previously_saved
-      get search_outgoing_trust_incoming_trusts_url(outgoing_trust.id), params: params
+      post outgoing_trust_incoming_trusts_url(outgoing_trust.id), params: params
     end
 
     it "Redirects to new projects for single result" do
@@ -60,7 +60,7 @@ RSpec.describe "IncomingTrusts", type: :request do
       let(:trusts) { build_list :trust, 2, trust_name: query }
       let(:incoming_trust) { trusts.first }
       let(:link_back_to_search) do
-        search_outgoing_trust_incoming_trusts_path(
+        outgoing_trust_incoming_trusts_path(
           outgoing_trust.id,
           "input-autocomplete" => incoming_trust.trust_name,
           commit: I18n.t("incoming_trusts.index.add_trust"),
@@ -77,7 +77,7 @@ RSpec.describe "IncomingTrusts", type: :request do
       end
 
       it "renders search template" do
-        expect(response.body).to include(I18n.t("incoming_trusts.search.heading"))
+        expect(response.body).to include(I18n.t("incoming_trusts.create.heading"))
       end
     end
 


### PR DESCRIPTION
### Context
A small refactor to move a custom action to a standard resource action

### Changes proposed in this pull request
The action incoming_trusts#search is moved to incoming_trusts#create


